### PR TITLE
chore: add linter for actions yamls

### DIFF
--- a/.github/workflows/actions-ci-check.yaml
+++ b/.github/workflows/actions-ci-check.yaml
@@ -1,0 +1,8 @@
+name: Actions yaml CI check
+on: [pull_request]
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: reviewdog/action-actionlint@v1


### PR DESCRIPTION
This commit enable CI check to verify actions yaml using [actionslint](https://github.com/rhysd/actionlint).

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>