### PR TITLE
fix: set repo scope when retrieving token from app credentials

### DIFF
--- a/.github/workflows/update-cmo-jsonnet-deps.yaml
+++ b/.github/workflows/update-cmo-jsonnet-deps.yaml
@@ -28,12 +28,14 @@ jobs:
       with:
         app_id: ${{ secrets.APP_ID }}
         private_key: ${{ secrets.APP_PRIVATE_KEY }}
+        scope: openshift
     - name: get cloner app token
       id: cloner
       uses: getsentry/action-github-app-token@v1
       with:
         app_id: ${{ secrets.CLONER_APP_ID }}
         private_key: ${{ secrets.CLONER_APP_PRIVATE_KEY }}
+        scope: rhobs
     - name: Create Pull Request
       uses: arajkumar/create-pull-request@v3
       with:


### PR DESCRIPTION
Without a scope parameter, `getsentry/action-github-app-token@v1` might end up using different installation id when creating auth tokens. Refer https://github.com/getsentry/action-github-app-token/pull/11 for more details.

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>