### PR TITLE
Reusable merge flow

### DIFF
--- a/.github/workflows/merge-flow.yaml
+++ b/.github/workflows/merge-flow.yaml
@@ -24,12 +24,12 @@ on:
         required: true
         type: string
       theirs:
-        description: Resets using upstream content during merge conflict.
+        description: List of files to be reset using upstream content on merge conflict.
         required: false
         default: ''
         type: string
       ours:
-        description: Resets using downstream content during merge conflict.
+        description: List of files to be reset using downstream content on merge conflict.
         required: false
         default: ''
         type: string

--- a/.github/workflows/merge-flow.yaml
+++ b/.github/workflows/merge-flow.yaml
@@ -1,0 +1,142 @@
+name: Common merge flow
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        description: go version
+        required: true
+        type: string
+      upstream:
+        description: Upstream repo path in owner/repo format
+        required: true
+        type: string
+      downstream:
+        description: Downstream repo path in owner/repo format
+        required: true
+        type: string
+      downstream-branch:
+        description: Downstream branch to create PR
+        required: false
+        default: master
+        type: string
+      sandbox:
+        description: Sandbox repo path in owner/repo format. Used a base to create PR against downstream.
+        required: true
+        type: string
+      theirs:
+        description: Resets using upstream content during merge conflict.
+        required: false
+        default: ''
+        type: string
+      ours:
+        description: Resets using downstream content during merge conflict.
+        required: false
+        default: ''
+        type: string
+    secrets:
+      cloner-app-id:
+        description: Github ID of cloner app
+        required: true
+      cloner-app-private-key:
+        description: Github private key of cloner app
+        required: true
+      pr-app-id:
+        description: Github ID of PR creation app
+        required: true
+      pr-app-private-key:
+        description: Github private key of PR creation app
+        required: true
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    name: perform merge operation
+    steps:
+      - name: get latest upstream tag
+        id: upstream
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          repository: ${{ inputs.upstream }}
+          excludes: prerelease, draft
+      - uses: actions/checkout@v2
+        with:
+          repository: ${{ inputs.downstream }}
+          fetch-depth: 0
+          ref: ${{ inputs.downstream-branch }}
+      - name: fetch upstream
+        run: |
+          echo latest tag is ${{ steps.upstream.outputs.release }}
+      - name: fetch upstream
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git config --global core.editor "/bin/true"
+          git fetch https://github.com/${{ inputs.upstream }} --tags
+      - name: merge upstream
+        id: merge
+        run: |
+          git merge refs/tags/${{ steps.upstream.outputs.release }} --no-edit || echo '::set-output name=MERGE_CONFLICT::true'
+      - name: resolve conflict using theirs
+        if: ${{ steps.merge.outputs.MERGE_CONFLICT == 'true' && inputs.theirs != ''}}
+        run: |
+            git checkout --theirs ${{ inputs.theirs }}
+            git add ${{ inputs.theirs }}
+      - name: resolve conflict using ours
+        if: ${{ steps.merge.outputs.MERGE_CONFLICT == 'true' && inputs.ours != ''}}
+        run: |
+            git checkout --ours ${{ inputs.ours }}
+            git add ${{ inputs.ours }}
+      - name: continue after merge conflict
+        if: ${{ steps.merge.outputs.MERGE_CONFLICT == 'true' }}
+        run: git merge --continue
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ inputs.go-version }}
+      - name: go mod vendor
+        run: go mod vendor
+      - name: find org name from repo name
+        id: org
+        run: |
+          echo "::set-output name=upstream::$(echo ${{ inputs.upstream }} | cut -d '/' -f 1)"
+          echo "::set-output name=downstream::$(echo ${{ inputs.downstream }} | cut -d '/' -f 1)"
+          echo "::set-output name=sandbox::$(echo ${{ inputs.sandbox }} | cut -d '/' -f 1)"
+      - name: get pr creation app token
+        id: pr
+        uses: getsentry/action-github-app-token@v1
+        with:
+          app_id: ${{ secrets.pr-app-id }}
+          private_key: ${{ secrets.pr-app-private-key }}
+          scope: ${{ steps.org.outputs.downstream }}
+      - name: get cloner app token
+        id: cloner
+        uses: getsentry/action-github-app-token@v1
+        with:
+          app_id: ${{ secrets.cloner-app-id }}
+          private_key: ${{ secrets.cloner-app-private-key }}
+          scope: ${{ steps.org.outputs.sandbox }}
+      - name: Create Pull Request
+        uses: arajkumar/create-pull-request@v3
+        with:
+          commit-message: "[bot] vendor: revendor"
+          title: "[bot] Bump ${{ inputs.downstream }} to ${{ steps.upstream.outputs.release }}"
+          body: |
+            ## Description
+            This is an automated version bump from CI.
+            If you wish to perform this manually, execute the following commands from ${{ inputs.downstream }} repo,
+            ```
+            git fetch https://github.com/${{ inputs.upstream }} --tags
+            if ! git merge refs/tags/${{ steps.upstream.outputs.release }} --no-edit; then
+              git checkout --theirs tutorials CHANGELOG.md VERSION
+              git add tutorials CHANGELOG.md VERSION
+              git merge --continue
+            fi
+            go mod vendor
+            ```
+          author: 'github-actions[bot]<github-actions[bot]@users.noreply.github.com>'
+          committer: 'github-actions[bot]<github-actions[bot]@users.noreply.github.com>'
+          signoff: true
+          branch: automated-updates-master
+          delete-branch: true
+          token: ${{ steps.pr.outputs.token }}
+          push-to-fork: ${{ inputs.sandbox }}
+          push-to-fork-token: ${{ steps.cloner.outputs.token }}

--- a/.github/workflows/merge-flow.yaml
+++ b/.github/workflows/merge-flow.yaml
@@ -23,12 +23,12 @@ on:
         description: Sandbox repo path in owner/repo format. Used a base to create PR against downstream.
         required: true
         type: string
-      theirs:
+      restore-upstream:
         description: List of files to be reset using upstream content on merge conflict.
         required: false
         default: ''
         type: string
-      ours:
+      restore-downstream:
         description: List of files to be reset using downstream content on merge conflict.
         required: false
         default: ''
@@ -50,9 +50,9 @@ on:
 jobs:
   merge:
     runs-on: ubuntu-latest
-    name: perform merge operation
+    name: Perform merge operation
     steps:
-      - name: get latest upstream tag
+      - name: Get latest upstream tag
         id: upstream
         uses: pozetroninc/github-action-get-latest-release@master
         with:
@@ -63,30 +63,29 @@ jobs:
           repository: ${{ inputs.downstream }}
           fetch-depth: 0
           ref: ${{ inputs.downstream-branch }}
-      - name: fetch upstream
-        run: |
-          echo latest tag is ${{ steps.upstream.outputs.release }}
-      - name: fetch upstream
+      - name: Fetch all upstream tags
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git config --global core.editor "/bin/true"
           git fetch https://github.com/${{ inputs.upstream }} --tags
-      - name: merge upstream
+      - name: Merge with upstream ${{ steps.upstream.outputs.release }} tag
         id: merge
         run: |
           git merge refs/tags/${{ steps.upstream.outputs.release }} --no-edit || echo '::set-output name=MERGE_CONFLICT::true'
-      - name: resolve conflict using theirs
-        if: ${{ steps.merge.outputs.MERGE_CONFLICT == 'true' && inputs.theirs != ''}}
+      - name: Resolve conflict using upstream contents
+        if: ${{ steps.merge.outputs.MERGE_CONFLICT == 'true' && inputs.restore-upstream != ''}}
         run: |
-            git checkout --theirs ${{ inputs.theirs }}
-            git add ${{ inputs.theirs }}
-      - name: resolve conflict using ours
-        if: ${{ steps.merge.outputs.MERGE_CONFLICT == 'true' && inputs.ours != ''}}
+            echo "reset ${{ inputs.restore-upstream }}"
+            git checkout --theirs ${{ inputs.restore-upstream }}
+            git add ${{ inputs.restore-upstream }}
+      - name: Resolve conflict using downstream contents
+        if: ${{ steps.merge.outputs.MERGE_CONFLICT == 'true' && inputs.restore-downstream != ''}}
         run: |
-            git checkout --ours ${{ inputs.ours }}
-            git add ${{ inputs.ours }}
-      - name: continue after merge conflict
+            echo "reset ${{ inputs.restore-downstream }}"
+            git checkout --ours ${{ inputs.restore-downstream }}
+            git add ${{ inputs.restore-downstream }}
+      - name: Continue after merge conflict
         if: ${{ steps.merge.outputs.MERGE_CONFLICT == 'true' }}
         run: git merge --continue
       - uses: actions/setup-go@v2
@@ -94,20 +93,19 @@ jobs:
           go-version: ${{ inputs.go-version }}
       - name: go mod vendor
         run: go mod vendor
-      - name: find org name from repo name
+      - name: Find github org name from repo name
         id: org
         run: |
-          echo "::set-output name=upstream::$(echo ${{ inputs.upstream }} | cut -d '/' -f 1)"
-          echo "::set-output name=downstream::$(echo ${{ inputs.downstream }} | cut -d '/' -f 1)"
-          echo "::set-output name=sandbox::$(echo ${{ inputs.sandbox }} | cut -d '/' -f 1)"
-      - name: get pr creation app token
+          echo "::set-output name=downstream::$(dirname ${{ inputs.downstream }})"
+          echo "::set-output name=sandbox::$(dirname ${{ inputs.sandbox }})"
+      - name: Get auth token to create pull request for ${{ inputs.downstream }}
         id: pr
         uses: getsentry/action-github-app-token@v1
         with:
           app_id: ${{ secrets.pr-app-id }}
           private_key: ${{ secrets.pr-app-private-key }}
           scope: ${{ steps.org.outputs.downstream }}
-      - name: get cloner app token
+      - name: Get auth token to push to ${{ inputs.sandbox }}
         id: cloner
         uses: getsentry/action-github-app-token@v1
         with:
@@ -126,8 +124,9 @@ jobs:
             ```
             git fetch https://github.com/${{ inputs.upstream }} --tags
             if ! git merge refs/tags/${{ steps.upstream.outputs.release }} --no-edit; then
-              git checkout --theirs tutorials CHANGELOG.md VERSION
-              git add tutorials CHANGELOG.md VERSION
+              git checkout --theirs ${{ inputs.restore-upstream }}
+              git checkout --ours ${{ inputs.restore-downstream }}
+              git add ${{ inputs.restore-upstream }} ${{ inputs.restore-downstream }}
               git merge --continue
             fi
             go mod vendor
@@ -135,7 +134,7 @@ jobs:
           author: 'github-actions[bot]<github-actions[bot]@users.noreply.github.com>'
           committer: 'github-actions[bot]<github-actions[bot]@users.noreply.github.com>'
           signoff: true
-          branch: automated-updates-master
+          branch: automated-updates-${{ inputs.downstream-branch }}
           delete-branch: true
           token: ${{ steps.pr.outputs.token }}
           push-to-fork: ${{ inputs.sandbox }}

--- a/.github/workflows/merge-thanose.yaml
+++ b/.github/workflows/merge-thanose.yaml
@@ -12,7 +12,7 @@ jobs:
       downstream: openshift/thanos
       sandbox: rhobs/thanos
       go-version: 1.17
-      theirs: tutorials CHANGELOG.md VERSION
+      restore-upstream: tutorials CHANGELOG.md VERSION
     secrets:
       pr-app-id: ${{ secrets.APP_ID }}
       pr-app-private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/merge-thanose.yaml
+++ b/.github/workflows/merge-thanose.yaml
@@ -1,0 +1,20 @@
+name: Thanos merger
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' #@daily
+jobs:
+  thanos-merge:
+    uses: rhobs/syncbot/.github/workflows/merge-flow.yaml@main
+    with:
+      upstream: thanos-io/thanos
+      downstream: openshift/thanos
+      sandbox: rhobs/thanos
+      go-version: 1.17
+      theirs: tutorials CHANGELOG.md VERSION
+    secrets:
+      pr-app-id: ${{ secrets.APP_ID }}
+      pr-app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      cloner-app-id: ${{ secrets.CLONER_APP_ID }}
+      cloner-app-private-key: ${{ secrets.CLONER_APP_PRIVATE_KEY }}


### PR DESCRIPTION
This commit introduces a merge flow based on GH action's reusable
workflows concept[1]. Reusable merge flow takes upstream,
downstream, sandbox and related secrets as input and executes the
defined merge flow.

It executes the following steps,

1. Find the latest release tag for the given `upstream`
2. Clone the `downstream`
3. Perform `git merge upstream/${latest_tag}`
4. Fix merge conflicts using `theirs` and `ours` input
      theirs - resets the file using upstream content
      ours - resets the file using downstream content
5. Perform `go mod vendor`
6. Push changes to `sandbox` repo to create a PR
6. Raise a PR to `downstream` using `sandbox`

For example, the following commands will be executed for `openshift/thanos`,

```
LATEST_TAG=$(curl -s https://api.github.com/repos/thanos-io/thanos/releases/latest -o - | jq -r .tag_name)
git clone https://github.com/openshift/thanos
cd thanos
git fetch https://github.com/thanos-io/thanos --tags
if ! git merge refs/tags/${LATEST_TAG} --no-edit; then
  git checkout --theirs tutorials CHANGELOG.md VERSION
  git add tutorials CHANGELOG.md VERSION
  git merge --continue
fi
go mod vendor
git add .
git commit -s -m "revendor"
git push https://github.com/rhobs/thanos HEAD:automated-updates-master
```

Sample PR created by the workflow: https://github.com/syncbot-io/thanos/pull/8

[1] https://docs.github.com/en/actions/learn-github-actions/reusing-workflows