### PR TITLE
Add generic make target workflow executor for cmo

### DIFF
--- a/.github/workflows/cmo-make-targets.yaml
+++ b/.github/workflows/cmo-make-targets.yaml
@@ -1,0 +1,81 @@
+name: cluster-monitoring-operator make targets
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        description: go version
+        required: true
+        type: string
+      pr-title:
+        description: Pull request title.
+        required: true
+        type: string
+      pr-body:
+        description: Pull request body.
+        required: true
+        type: string
+      make-targets:
+        description: List of make targets to be executed sequentially.
+        required: true
+        type: string
+    secrets:
+      cloner-app-id:
+        description: Github ID of cloner app
+        required: true
+      cloner-app-private-key:
+        description: Github private key of cloner app
+        required: true
+      pr-app-id:
+        description: Github ID of PR creation app
+        required: true
+      pr-app-private-key:
+        description: Github private key of PR creation app
+        required: true
+env:
+  USER: 'github-actions[bot]<github-actions[bot]@users.noreply.github.com>'
+
+jobs:
+  execute-make-targets:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        repository: openshift/cluster-monitoring-operator
+        ref: master
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ inputs.go-version }}
+    - name: Execute make targets - ${{ inputs.make-targets }}
+      run: make ${{ inputs.make-targets }}
+    - name: get pr creation app token
+      id: pr
+      uses: getsentry/action-github-app-token@v1
+      with:
+        app_id: ${{ secrets.pr-app-id }}
+        private_key: ${{ secrets.pr-app-private-key }}
+        scope: openshift
+    - name: get cloner app token
+      id: cloner
+      uses: getsentry/action-github-app-token@v1
+      with:
+        app_id: ${{ secrets.cloner-app-id }}
+        private_key: ${{ secrets.cloner-app-private-key }}
+        scope: rhobs
+    - name: Find branch name
+      id: branch
+      run: |
+        echo "::set-output name=sandbox::$(echo ${{ inputs.make-targets }} | sed 's/ /-/g')"
+    - name: Create Pull Request
+      uses: arajkumar/create-pull-request@v3
+      with:
+        commit-message: ${{ inputs.pr-title }}
+        title: ${{ inputs.pr-title }}
+        body: ${{ inputs.pr-body }}
+        author: ${{ env.USER }}
+        committer: ${{ env.USER }}
+        signoff: true
+        branch: automated-updates-master-${{ steps.branch.outputs.sandbox }}
+        delete-branch: true
+        token: ${{ steps.pr.outputs.token }}
+        push-to-fork: rhobs/cluster-monitoring-operator
+        push-to-fork-token: ${{ steps.cloner.outputs.token }}

--- a/.github/workflows/update-cmo-jsonnet-deps.yaml
+++ b/.github/workflows/update-cmo-jsonnet-deps.yaml
@@ -3,58 +3,25 @@ name: Upgrade cluster-monitoring-operator jsonnet dependencies
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 1'
-env:
-  USER: 'github-actions[bot]<github-actions[bot]@users.noreply.github.com>'
-
+    - cron: '0 0 * * 1' #@weekly
 jobs:
   jsonnet-update:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        repository: openshift/cluster-monitoring-operator
-        ref: master
-    - uses: actions/setup-go@v2
-      with:
-        go-version: 1.16
-    - name: update jsonnet dependencies
-      run: make update
-    - name: generate yaml assets
-      run: make generate
-    - name: get pr creation app token
-      id: pr
-      uses: getsentry/action-github-app-token@v1
-      with:
-        app_id: ${{ secrets.APP_ID }}
-        private_key: ${{ secrets.APP_PRIVATE_KEY }}
-        scope: openshift
-    - name: get cloner app token
-      id: cloner
-      uses: getsentry/action-github-app-token@v1
-      with:
-        app_id: ${{ secrets.CLONER_APP_ID }}
-        private_key: ${{ secrets.CLONER_APP_PRIVATE_KEY }}
-        scope: rhobs
-    - name: Create Pull Request
-      uses: arajkumar/create-pull-request@v3
-      with:
-        commit-message: "[bot] Automated jsonnet dependencies update"
-        title: "[bot] Automated jsonnet dependencies update"
-        body: |
-          ## Description
-          This is an automated version and jsonnet dependencies update performed from CI.
+    uses: rhobs/syncbot/.github/workflows/cmo-make-targets.yaml@main
+    with:
+      go-version: 1.17
+      make-targets: update generate
+      pr-title: "[bot] Automated jsonnet dependencies update"
+      pr-body: |
+        ## Description
+        This is an automated jsonnet dependencies update performed from CI.
 
-          If you wish to perform this manually, execute the following commands from cluster-monitoring-operator repo,
-          ```
-          make update
-          make generate
-          ```
-        author: ${{ env.USER }}
-        committer: ${{ env.USER }}
-        signoff: true
-        branch: automated-updates-master
-        delete-branch: true
-        token: ${{ steps.pr.outputs.token }}
-        push-to-fork: rhobs/cluster-monitoring-operator
-        push-to-fork-token: ${{ steps.cloner.outputs.token }}
+        If you wish to perform this manually, execute the following commands from cluster-monitoring-operator repo,
+        ```
+        make update
+        make generate
+        ```
+    secrets:
+      pr-app-id: ${{ secrets.APP_ID }}
+      pr-app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      cloner-app-id: ${{ secrets.CLONER_APP_ID }}
+      cloner-app-private-key: ${{ secrets.CLONER_APP_PRIVATE_KEY }}


### PR DESCRIPTION
This would enable us to hook `make versions` target by reusing most of the workflow part. I will create a follow PR to add workflow to perform `make versions` for CMO, which would update [jsonnet/versions.yaml](https://github.com/openshift/cluster-monitoring-operator/blob/master/jsonnet/versions.yaml) periodically.