### PR TITLE
Remove emptiness check for slack webhook

### DIFF
--- a/.github/workflows/cmo-make-targets.yaml
+++ b/.github/workflows/cmo-make-targets.yaml
@@ -33,7 +33,7 @@ on:
         required: true
       slack-webhook-url:
         description: Slack webhook URL to send notification
-        required: false
+        required: true
 env:
   USER: 'github-actions[bot]<github-actions[bot]@users.noreply.github.com>'
 

--- a/.github/workflows/cmo-make-targets.yaml
+++ b/.github/workflows/cmo-make-targets.yaml
@@ -85,7 +85,7 @@ jobs:
         push-to-fork-token: ${{ steps.cloner.outputs.token }}
     - uses: 8398a7/action-slack@v3
       continue-on-error: true
-      if: ${{ success() && secrets.slack-webhook-url != '' }}
+      if: success()
       with:
         status: custom
         fields: workflow
@@ -100,7 +100,7 @@ jobs:
         SLACK_WEBHOOK_URL: ${{ secrets.slack-webhook-url }}
     - uses: 8398a7/action-slack@v3
       continue-on-error: true
-      if: ${{ failure() && secrets.slack-webhook-url != '' }}
+      if: failure()
       with:
         status: custom
         fields: workflow

--- a/.github/workflows/merge-flow.yaml
+++ b/.github/workflows/merge-flow.yaml
@@ -48,7 +48,7 @@ on:
         required: true
       slack-webhook-url:
         description: Slack webhook URL to send notification
-        required: false
+        required: true
 
 jobs:
   merge:

--- a/.github/workflows/merge-flow.yaml
+++ b/.github/workflows/merge-flow.yaml
@@ -145,7 +145,7 @@ jobs:
           push-to-fork-token: ${{ steps.cloner.outputs.token }}
       - uses: 8398a7/action-slack@v3
         continue-on-error: true
-        if: ${{ success() && secrets.slack-webhook-url != '' }}
+        if: success()
         with:
           status: custom
           fields: workflow
@@ -160,7 +160,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.slack-webhook-url }}
       - uses: 8398a7/action-slack@v3
         continue-on-error: true
-        if: ${{ failure() && secrets.slack-webhook-url != '' }}
+        if: failure()
         with:
           status: custom
           fields: workflow


### PR DESCRIPTION
Github Actions doesn't allow testing secrets in `if:` clause. Anyways
this emptiness check is no longer needed as all the workflows must pass
slack webhook secret.

Refer https://github.com/actions/runner/issues/520

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>