### PR TITLE
Format slack message according to the nature of action

### DIFF
--- a/.github/workflows/cmo-make-targets.yaml
+++ b/.github/workflows/cmo-make-targets.yaml
@@ -83,6 +83,14 @@ jobs:
         token: ${{ steps.pr.outputs.token }}
         push-to-fork: rhobs/cluster-monitoring-operator
         push-to-fork-token: ${{ steps.cloner.outputs.token }}
+    - name: Compose slack message body
+      id: slack-message
+      run: |
+        if [ "${{ steps.create-pr.outputs.pull-request-url }}" == "" ]; then
+          echo '::set-output name=message::No changes detected.'
+        else
+          echo '::set-output name=message::PR ${{ steps.create-pr.outputs.pull-request-url }} has been ${{ steps.create-pr.outputs.pull-request-operation }}.'
+        fi
     - uses: 8398a7/action-slack@v3
       continue-on-error: true
       if: success()
@@ -93,7 +101,7 @@ jobs:
           {
             attachments: [{
               color: 'good',
-              text: `${process.env.AS_WORKFLOW}\n PR ${{ steps.create-pr.outputs.pull-request-url }} has been ${{ steps.create-pr.outputs.pull-request-operation }} .`,
+              text: `${process.env.AS_WORKFLOW}\n ${{ steps.slack-message.outputs.message }}`,
             }]
           }
       env:

--- a/.github/workflows/merge-flow.yaml
+++ b/.github/workflows/merge-flow.yaml
@@ -143,6 +143,14 @@ jobs:
           token: ${{ steps.pr.outputs.token }}
           push-to-fork: ${{ inputs.sandbox }}
           push-to-fork-token: ${{ steps.cloner.outputs.token }}
+      - name: Compose slack message body
+        id: slack-message
+        run: |
+          if [ "${{ steps.create-pr.outputs.pull-request-url }}" == "" ]; then
+            echo '::set-output name=message::${{ inputs.downstream }} is already upto date with tag ${{ steps.upstream.outputs.release }}.'
+          else
+            echo '::set-output name=message::PR ${{ steps.create-pr.outputs.pull-request-url }} has been ${{ steps.create-pr.outputs.pull-request-operation }}.'
+          fi
       - uses: 8398a7/action-slack@v3
         continue-on-error: true
         if: success()
@@ -153,7 +161,7 @@ jobs:
             {
               attachments: [{
                 color: 'good',
-                text: `${process.env.AS_WORKFLOW}\n PR ${{ steps.create-pr.outputs.pull-request-url }} has been ${{ steps.create-pr.outputs.pull-request-operation }} .`,
+                text: `${process.env.AS_WORKFLOW}\n ${{ steps.slack-message.outputs.message }}`,
               }]
             }
         env:


### PR DESCRIPTION
Introduce a dedicated step to format the slack message according to the
PR creation step.

### Before:
<img width="337" alt="Screenshot 2021-12-14 at 3 29 09 PM" src="https://user-images.githubusercontent.com/3874763/145976159-78bafad0-85d1-4999-b67b-776846f4fb73.png">

### After:
<img width="429" alt="Screenshot 2021-12-14 at 3 29 37 PM" src="https://user-images.githubusercontent.com/3874763/145976235-29ca829a-e815-4ebc-80ee-e5b25d9abb12.png">

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>