### PR TITLE
Don't create PR when changes are only in jsonnetfile.lock.json

### DIFF
--- a/.github/workflows/cmo-make-targets.yaml
+++ b/.github/workflows/cmo-make-targets.yaml
@@ -50,6 +50,13 @@ jobs:
         go-version: ${{ inputs.go-version }}
     - name: Execute make targets - ${{ inputs.make-targets }}
       run: make ${{ inputs.make-targets }}
+    - name: Ignore if change is only in jsonnetfile.lock.json
+      run: |
+        # Reset jsonnetfile.lock.json if no dependencies were updated
+        changedFiles=$(git diff --name-only | grep -cv 'jsonnetfile.lock.json')
+        if [[ "$changedFiles" -eq 0 ]]; then
+          git checkout -- jsonnetfile.lock.json;
+        fi
     - name: get pr creation app token
       id: pr
       uses: getsentry/action-github-app-token@v1


### PR DESCRIPTION
Inspired from https://github.com/prometheus-operator/kube-prometheus/blob/9b532dac0c8b00e984d2f77b2f2f0ef0dae6e751/.github/workflows/versions.yaml#L42-L45

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>