### PR TITLE
Remove dependabot config during merge

### DIFF
--- a/.github/workflows/merge-flow.yaml
+++ b/.github/workflows/merge-flow.yaml
@@ -94,6 +94,11 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ inputs.go-version }}
+      - name: Remove dependabot configuration
+        continue-on-error: true
+        run: |
+          rm -f .github/dependabot.*
+          git commit -a -s -m "[bot] remove dependabot config"
       - name: go mod vendor
         run: go mod vendor
       - name: Find github org name from repo name


### PR DESCRIPTION
Dependabot is a GH app which automatically monitors repos with `.github/dependabot.yaml` files and keeps raising pull requests incase if it finds outdated dependencies or dependencies with vulnerabilities. However Openshift has a PST based workflow for security notification and remediation. 

Fixes https://github.com/rhobs/syncbot/issues/23

Ref https://github.com/openshift/prometheus/pull/115

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>