### PR TITLE
Fix broken slack message body

### DIFF
--- a/.github/workflows/cmo-make-targets.yaml
+++ b/.github/workflows/cmo-make-targets.yaml
@@ -94,9 +94,9 @@ jobs:
       id: slack-message
       run: |
         if [ "${{ steps.create-pr.outputs.pull-request-url }}" == "" ]; then
-          echo '::set-output name=message::No changes detected.'
+          echo "::set-output name=message::No changes detected."
         else
-          echo '::set-output name=message::PR ${{ steps.create-pr.outputs.pull-request-url }} has been ${{ steps.create-pr.outputs.pull-request-operation }}.'
+          echo "::set-output name=message::PR ${{ steps.create-pr.outputs.pull-request-url }} has been ${{ steps.create-pr.outputs.pull-request-operation || 'updated' }}."
         fi
     - uses: 8398a7/action-slack@v3
       continue-on-error: true


### PR DESCRIPTION
`create-pull-request` action returns empty status when there is already a pull request present and no changes detected. Substitute empty status with `updated`.

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>