### PR TITLE
prometheus: adjust asset generation to embed usage

### DIFF
--- a/.github/workflows/merge-prometheus.yaml
+++ b/.github/workflows/merge-prometheus.yaml
@@ -19,8 +19,9 @@ jobs:
         go.sum
         .golangci.yml
       assets-cmd: |
-        make assets
-        git add web/ui/assets_vfsdata.go
+        make assets-compress
+        find web/ui/static/react -type f -name '*.gz' -exec git add {} -f \;
+        git add web/ui/embed.go -f
         git diff --cached --exit-code || git commit -s -m "[bot] assets: generate"
 
     secrets:


### PR DESCRIPTION
With https://github.com/prometheus/prometheus/pull/10220 and
https://github.com/prometheus/prometheus/pull/10467 prometheus no longer
needs a dedicated asset generation step. This change made in into
prometheus v2.35.0.
We still need to generate the assets and commit them to the repo though, as the build environment can not access npm.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>