### PR TITLE
Bump to Go 1.19 for all workflows

### DIFF
--- a/.github/workflows/merge-alertmanager.yaml
+++ b/.github/workflows/merge-alertmanager.yaml
@@ -11,7 +11,7 @@ jobs:
       upstream: prometheus/alertmanager
       downstream: openshift/prometheus-alertmanager
       sandbox: rhobs/prometheus-alertmanager
-      go-version: 1.17
+      go-version: 1.19
       restore-upstream: >-
          CHANGELOG.md
          VERSION

--- a/.github/workflows/merge-kube-state-metrics.yaml
+++ b/.github/workflows/merge-kube-state-metrics.yaml
@@ -12,7 +12,7 @@ jobs:
       upstream: kubernetes/kube-state-metrics
       downstream: openshift/kube-state-metrics
       sandbox: rhobs/kube-state-metrics
-      go-version: 1.17
+      go-version: 1.19
       restore-upstream: CHANGELOG.md VERSION
       restore-downstream: OWNERS
     secrets:

--- a/.github/workflows/merge-node-exporter.yaml
+++ b/.github/workflows/merge-node-exporter.yaml
@@ -11,7 +11,7 @@ jobs:
       upstream: prometheus/node_exporter
       downstream: openshift/node_exporter
       sandbox: rhobs/node_exporter
-      go-version: 1.17
+      go-version: 1.19
       restore-downstream: >-
          OWNERS
       restore-upstream: >-

--- a/.github/workflows/merge-prom-label-proxy.yaml
+++ b/.github/workflows/merge-prom-label-proxy.yaml
@@ -11,7 +11,7 @@ jobs:
       upstream: prometheus-community/prom-label-proxy
       downstream: openshift/prom-label-proxy
       sandbox: rhobs/prom-label-proxy
-      go-version: 1.17
+      go-version: 1.19
       restore-downstream: >-
          OWNERS
       restore-upstream: >-

--- a/.github/workflows/merge-prometheus-adapter.yaml
+++ b/.github/workflows/merge-prometheus-adapter.yaml
@@ -11,7 +11,7 @@ jobs:
       upstream: kubernetes-sigs/prometheus-adapter
       downstream: openshift/k8s-prometheus-adapter
       sandbox: rhobs/k8s-prometheus-adapter
-      go-version: 1.17
+      go-version: 1.19
       restore-downstream: >-
          OWNERS
       restore-upstream: >-

--- a/.github/workflows/merge-prometheus-operator.yaml
+++ b/.github/workflows/merge-prometheus-operator.yaml
@@ -11,7 +11,7 @@ jobs:
       upstream: prometheus-operator/prometheus-operator
       downstream: openshift/prometheus-operator
       sandbox: rhobs/prometheus-operator
-      go-version: 1.17
+      go-version: 1.19
       restore-upstream: >-
         CHANGELOG.md
         Documentation

--- a/.github/workflows/merge-prometheus.yaml
+++ b/.github/workflows/merge-prometheus.yaml
@@ -11,7 +11,7 @@ jobs:
       upstream: prometheus/prometheus
       downstream: openshift/prometheus
       sandbox: rhobs/prometheus
-      go-version: 1.17
+      go-version: 1.19
       restore-upstream: >-
         CHANGELOG.md
         VERSION

--- a/.github/workflows/merge-thanos.yaml
+++ b/.github/workflows/merge-thanos.yaml
@@ -11,7 +11,7 @@ jobs:
       upstream: thanos-io/thanos
       downstream: openshift/thanos
       sandbox: rhobs/thanos
-      go-version: 1.17
+      go-version: 1.19
       restore-upstream: >-
         CHANGELOG.md
         VERSION

--- a/.github/workflows/update-cmo-deps-versions.yaml
+++ b/.github/workflows/update-cmo-deps-versions.yaml
@@ -10,7 +10,7 @@ jobs:
   versions-update:
     uses: rhobs/syncbot/.github/workflows/cmo-make-targets.yaml@main
     with:
-      go-version: 1.17
+      go-version: 1.19
       make-targets: versions generate
       pr-title: "[bot] Synchronize versions of the downstream components"
       pr-body: |

--- a/.github/workflows/update-cmo-jsonnet-deps.yaml
+++ b/.github/workflows/update-cmo-jsonnet-deps.yaml
@@ -8,7 +8,7 @@ jobs:
   jsonnet-update:
     uses: rhobs/syncbot/.github/workflows/cmo-make-targets.yaml@main
     with:
-      go-version: 1.17
+      go-version: 1.19
       make-targets: update generate
       pr-title: "[bot] Update jsonnet dependencies"
       pr-body: |


### PR DESCRIPTION
It looks like the `versions-update` workflow fails because it expects Go 1.19:

https://github.com/rhobs/syncbot/commit/8fa2c445c16873473fedeb0ce6a66ecfc741f8f5/checks