### PR TITLE
Makes repo comply with the deprecation of set-output

### DIFF
--- a/.github/workflows/cmo-make-targets.yaml
+++ b/.github/workflows/cmo-make-targets.yaml
@@ -74,7 +74,7 @@ jobs:
     - name: Find branch name
       id: branch
       run: |
-        echo "::set-output name=sandbox::$(echo ${{ inputs.make-targets }} | sed 's/ /-/g')"
+        echo "name=sandbox::$(echo ${{ inputs.make-targets }} | sed 's/ /-/g')" >> $GITHUB_OUTPUT
     - name: Create Pull Request
       id: create-pr
       uses: rhobs/create-pull-request@v3
@@ -94,9 +94,9 @@ jobs:
       id: slack-message
       run: |
         if [ "${{ steps.create-pr.outputs.pull-request-url }}" == "" ]; then
-          echo "::set-output name=message::No changes detected."
+          echo "name=message::No changes detected." >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=message::PR ${{ steps.create-pr.outputs.pull-request-url }} has been ${{ steps.create-pr.outputs.pull-request-operation || 'updated' }}."
+          echo "name=message::PR ${{ steps.create-pr.outputs.pull-request-url }} has been ${{ steps.create-pr.outputs.pull-request-operation || 'updated' }}." >> $GITHUB_OUTPUT
         fi
     - uses: 8398a7/action-slack@v3
       continue-on-error: true

--- a/.github/workflows/merge-flow.yaml
+++ b/.github/workflows/merge-flow.yaml
@@ -74,17 +74,17 @@ jobs:
       - name: Find github org name from repo name
         id: org
         run: |
-          echo "::set-output name=upstream::$(dirname ${{ inputs.upstream }})"
-          echo "::set-output name=downstream::$(dirname ${{ inputs.downstream }})"
-          echo "::set-output name=sandbox::$(dirname ${{ inputs.sandbox }})"
+          echo "name=upstream::$(dirname ${{ inputs.upstream }})" >> $GITHUB_OUTPUT
+          echo "name=downstream::$(dirname ${{ inputs.downstream }})" >> $GITHUB_OUTPUT
+          echo "name=sandbox::$(dirname ${{ inputs.sandbox }})" >> $GITHUB_OUTPUT
       - name: Check openshift fork is upto date
         id: fork-sync
         run: |
           AHEAD_BY=$(curl -s "https://api.github.com/repos/${{ inputs.downstream }}/compare/{${{ inputs.downstream-branch }}}...{${{ steps.org.outputs.upstream }}:${{steps.upstream.outputs.release }}}" -o - | jq .ahead_by)
           if [ "${AHEAD_BY}" != "0" ]; then
-            echo "::set-output name=status::outdated"
+            echo "name=status::outdated" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=status::uptodate"
+            echo "name=status::uptodate" >> $GITHUB_OUTPUT
             exit 1
           fi
       - uses: actions/checkout@v2
@@ -101,7 +101,7 @@ jobs:
       - name: Merge with upstream ${{ steps.upstream.outputs.release }} tag
         id: merge
         run: |
-          git merge refs/tags/${{ steps.upstream.outputs.release }} --no-edit || echo '::set-output name=MERGE_CONFLICT::true'
+          git merge refs/tags/${{ steps.upstream.outputs.release }} --no-edit || echo 'name=MERGE_CONFLICT::true' >> $GITHUB_OUTPUT
       - name: Resolve conflict using upstream contents
         if: ${{ steps.merge.outputs.MERGE_CONFLICT == 'true' && inputs.restore-upstream != ''}}
         run: |
@@ -197,9 +197,9 @@ jobs:
         id: slack-message
         run: |
           if [ "${{ steps.create-pr.outputs.pull-request-url }}" == "" ] || [ ${{ steps.fork-sync.outputs.status }} == "uptodate" ] ; then
-            echo "::set-output name=message::${{ inputs.downstream }} is already upto date with tag ${{ steps.upstream.outputs.release }}."
+            echo "name=message::${{ inputs.downstream }} is already upto date with tag ${{ steps.upstream.outputs.release }}." >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=message::PR ${{ steps.create-pr.outputs.pull-request-url }} has been ${{ steps.create-pr.outputs.pull-request-operation || 'updated' }}."
+            echo "name=message::PR ${{ steps.create-pr.outputs.pull-request-url }} has been ${{ steps.create-pr.outputs.pull-request-operation || 'updated' }}." >> $GITHUB_OUTPUT
           fi
       - uses: 8398a7/action-slack@v3
         continue-on-error: true


### PR DESCRIPTION
Problem: GitHub has announced the deprecation of `set-output` by June 2023. See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Solution: comply with the change as instructed in the blogpost