### PR TITLE
merge-flow: add manual instruction for assets and rh-manifest.txt

### DIFF
--- a/.github/workflows/merge-flow.yaml
+++ b/.github/workflows/merge-flow.yaml
@@ -182,6 +182,12 @@ jobs:
             fi
             go mod tidy
             go mod vendor
+            ${{ inputs.assets-cmd }}
+            if [ -f scripts/rh-manifest.sh ]; then
+              bash scripts/rh-manifest.sh
+              git add rh-manifest.txt
+              git diff --cached --exit-code || git commit -s -m "[bot] update rh-manifest.txt"
+            fi
             ```
           author: 'github-actions[bot]<github-actions[bot]@users.noreply.github.com>'
           committer: 'github-actions[bot]<github-actions[bot]@users.noreply.github.com>'


### PR DESCRIPTION
The asset generation and add steps are taken from the worklfows `asset-cmd` input.
The rh-manifest.txt steps are copied from the actual step. That not ideal, as they can diverge, though I don't expect that to happen very often.