### PR TITLE
Fix metrics-server merger go version

### DIFF
--- a/.github/workflows/merge-metrics-server.yaml
+++ b/.github/workflows/merge-metrics-server.yaml
@@ -12,8 +12,8 @@ jobs:
       upstream: kubernetes-sigs/metrics-server
       downstream: openshift/kubernetes-metrics-server
       sandbox: rhobs/kubernetes-metrics-server
-      go-version: 1.19
-      restore-upstream: CHANGELOG.md VERSION
+      go-version: 1.20
+      # restore-upstream:
       restore-downstream: OWNERS charts/OWNERS
     secrets:
       pr-app-id: ${{ secrets.APP_ID }}


### PR DESCRIPTION
Based on https://github.com/rhobs/syncbot/actions/runs/5682178454/job/15399991502#step:8:10
currently it looks like we don't have anything to restore from upstream