### PR TITLE
MON-2801: [follow-up] respect 'ahead' status

### DIFF
--- a/.github/workflows/merge-flow.yaml
+++ b/.github/workflows/merge-flow.yaml
@@ -222,17 +222,17 @@ jobs:
           push-to-fork-token: ${{ steps.cloner.outputs.token }}
       - name: Compose slack message body
         continue-on-error: true
-        if: success() || steps.fork-sync.outputs.status == 'uptodate'
+        if: success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead'
         id: slack-message
         run: |
-          if [ "${{ steps.create-pr.outputs.pull-request-url }}" == "" ] || [ ${{ steps.fork-sync.outputs.status }} == "uptodate" ] ; then
-            echo "message=${{ inputs.downstream }} is already upto date with tag ${{ steps.upstream.outputs.release }}." >> $GITHUB_OUTPUT
+          if [ "${{ steps.create-pr.outputs.pull-request-url }}" == "" ] || [ ${{ steps.fork-sync.outputs.status }} == "uptodate" ] || [ ${{ steps.fork-sync.outputs.status }} == "ahead" ] ; then
+            echo "message=${{ inputs.downstream }} is already ${{ steps.fork-sync.outputs.status }} with tag ${{ steps.upstream.outputs.release }}." >> $GITHUB_OUTPUT
           else
             echo "message=PR ${{ steps.create-pr.outputs.pull-request-url }} has been ${{ steps.create-pr.outputs.pull-request-operation || 'updated' }}." >> $GITHUB_OUTPUT
           fi
       - uses: 8398a7/action-slack@v3
         continue-on-error: true
-        if: success() || steps.fork-sync.outputs.status == 'uptodate'
+        if: success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead'
         with:
           status: custom
           fields: workflow
@@ -247,7 +247,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.slack-webhook-url }}
       - uses: 8398a7/action-slack@v3
         continue-on-error: true
-        if: failure() && steps.fork-sync.outputs.status != 'uptodate'
+        if: failure() && steps.fork-sync.outputs.status != 'uptodate' && steps.fork-sync.outputs.status != 'ahead'
         with:
           status: custom
           fields: workflow


### PR DESCRIPTION
Interpret `ahead` in the same way as `uptodate`.