### PR TITLE
MON-3330: [follow-up] add `downstream-version-expression`

### DIFF
--- a/.github/workflows/merge-alertmanager.yaml
+++ b/.github/workflows/merge-alertmanager.yaml
@@ -11,7 +11,7 @@ jobs:
       upstream: prometheus/alertmanager
       downstream: openshift/prometheus-alertmanager
       sandbox: rhobs/prometheus-alertmanager
-      go-version: 1.19
+      go-version: "1.20"
       restore-upstream: >-
          CHANGELOG.md
          VERSION

--- a/.github/workflows/merge-flow.yaml
+++ b/.github/workflows/merge-flow.yaml
@@ -43,6 +43,11 @@ on:
         required: false
         default: ''
         type: string
+      downstream-version-expression:
+        description: Expression to extract downstream version from downstream repo.
+        required: false
+        default: ''
+        type: string
     secrets:
       cloner-app-id:
         description: Github ID of cloner app
@@ -67,18 +72,35 @@ jobs:
     steps:
       - name: Get latest upstream tag
         id: upstream
-        uses: pozetroninc/github-action-get-latest-release@master
-        with:
-          repository: ${{ inputs.upstream }}
-          excludes: prerelease, draft
+        run: |
+          UPSTREAM_VERSION=$(curl --fail --silent "https://api.github.com/repos/${{ inputs.upstream }}/releases/latest" | jq -r '.tag_name')
+          if [ "$UPSTREAM_VERSION" == "" ]; then
+              echo "upstream-version is invalid" >> "$GITHUB_OUTPUT"
+              exit 1
+          fi
+          echo "release=${UPSTREAM_VERSION}" >> "$GITHUB_OUTPUT"
       - name: Find github org name from repo name
         id: org
         run: |
           echo "upstream=$(dirname ${{ inputs.upstream }})" >> $GITHUB_OUTPUT
           echo "downstream=$(dirname ${{ inputs.downstream }})" >> $GITHUB_OUTPUT
           echo "sandbox=$(dirname ${{ inputs.sandbox }})" >> $GITHUB_OUTPUT
-          # assumes the presence of ./VERSION
           DOWNSTREAM_VERSION=$(curl -sL "https://raw.githubusercontent.com/${{ inputs.downstream }}/${{ inputs.downstream-branch }}/VERSION")
+          if [ "${DOWNSTREAM_VERSION}" == "" ]; then
+            # Strip the trailing URL from the expression.
+            DOWNSTREAM_VERSION_SED=$(echo "${{ inputs.downstream-version-expression }}" | sed -e 's/\(http[^ ]*\).*$/\1/' -e 's/http[^ ]*$//')
+            # Strip the leading sed command from the expression.
+            DOWNSTREAM_VERSION_URL=$(echo "${{ inputs.downstream-version-expression }}" | sed -n 's/^.*\(http[^ ]*\).*$/\1/p')
+            if [ "${DOWNSTREAM_VERSION_SED}" == "" ] || [ "${DOWNSTREAM_VERSION_URL}" == "" ]; then
+              echo "::error::downstream-version-expression is invalid"
+              exit 1
+            fi
+            DOWNSTREAM_VERSION=$(curl --silent "${DOWNSTREAM_VERSION_URL}" | eval "${DOWNSTREAM_VERSION_SED}")
+            if [ "${DOWNSTREAM_VERSION}" == "" ]; then
+              echo "::error::downstream-version-expression is invalid"
+              exit 1
+            fi
+          fi
           echo "downstream-version=${DOWNSTREAM_VERSION}" >> $GITHUB_OUTPUT
       - uses: madhead/semver-utils@latest
         id: version
@@ -86,28 +108,21 @@ jobs:
           version: ${{ steps.org.outputs.downstream-version }}
           compare-to: ${{ steps.upstream.outputs.release }}
           lenient: false # fail if either of the versions cannot be parsed
-      - name: Check openshift fork is upto date
+      - name: Check openshift fork status
         id: fork-sync
         run: |
           SEMVER_RESULT="${{ steps.version.outputs.comparison-result }}"
           echo "${{ inputs.downstream }}@${{ steps.org.outputs.downstream-version }} ${SEMVER_RESULT} ${{ inputs.upstream }}@${{ steps.upstream.outputs.release }}"
           if [ "${SEMVER_RESULT}" == "<" ]; then
             echo "status=outdated" >> $GITHUB_OUTPUT
-            echo "downstream outdated"
+            echo "::notice::downstream outdated"
           elif [ "${SEMVER_RESULT}" == "=" ]; then
             echo "status=uptodate" >> $GITHUB_OUTPUT
-            echo "downstream up-to-date"
+            echo "::notice::downstream up-to-date"
             exit 1
           else
             echo "status=ahead" >> $GITHUB_OUTPUT
-            echo "downstream ahead"
-            exit 1
-          fi
-          AHEAD_BY=$(curl -s "https://api.github.com/repos/${{ inputs.downstream }}/compare/{${{ inputs.downstream-branch }}}...{${{ steps.org.outputs.upstream }}:${{steps.upstream.outputs.release }}}" -o - | jq .ahead_by)
-          if [ "${AHEAD_BY}" != "0" ]; then
-            echo "status=outdated" >> $GITHUB_OUTPUT
-          else
-            echo "status=uptodate" >> $GITHUB_OUTPUT
+            echo "::notice::downstream ahead"
             exit 1
           fi
       - uses: actions/checkout@v2
@@ -226,7 +241,7 @@ jobs:
         id: slack-message
         run: |
           if [ "${{ steps.create-pr.outputs.pull-request-url }}" == "" ] || [ ${{ steps.fork-sync.outputs.status }} == "uptodate" ] || [ ${{ steps.fork-sync.outputs.status }} == "ahead" ] ; then
-            echo "message=${{ inputs.downstream }} is already ${{ steps.fork-sync.outputs.status }} with tag ${{ steps.upstream.outputs.release }}." >> $GITHUB_OUTPUT
+            echo "message=${{ inputs.downstream }} is already ${{ steps.fork-sync.outputs.status }} with tag ${{ steps.org.outputs.downstream-version }}." >> $GITHUB_OUTPUT
           else
             echo "message=PR ${{ steps.create-pr.outputs.pull-request-url }} has been ${{ steps.create-pr.outputs.pull-request-operation || 'updated' }}." >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/merge-kube-state-metrics.yaml
+++ b/.github/workflows/merge-kube-state-metrics.yaml
@@ -12,7 +12,7 @@ jobs:
       upstream: kubernetes/kube-state-metrics
       downstream: openshift/kube-state-metrics
       sandbox: rhobs/kube-state-metrics
-      go-version: 1.19
+      go-version: "1.20"
       restore-upstream: CHANGELOG.md VERSION
       restore-downstream: OWNERS
     secrets:

--- a/.github/workflows/merge-metrics-server.yaml
+++ b/.github/workflows/merge-metrics-server.yaml
@@ -13,8 +13,9 @@ jobs:
       downstream: openshift/kubernetes-metrics-server
       sandbox: rhobs/kubernetes-metrics-server
       go-version: 1.20
-      # restore-upstream:
       restore-downstream: OWNERS charts/OWNERS
+      downstream-version-expression: |
+        sed -n -E 's/^.*newTag: *(v[0-9]+\.[0-9]+\.[0-9]+).*$/\1/p' https://raw.githubusercontent.com/openshift/kubernetes-metrics-server/master/manifests/release/kustomization.yaml
     secrets:
       pr-app-id: ${{ secrets.APP_ID }}
       pr-app-private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/merge-node-exporter.yaml
+++ b/.github/workflows/merge-node-exporter.yaml
@@ -11,7 +11,7 @@ jobs:
       upstream: prometheus/node_exporter
       downstream: openshift/node_exporter
       sandbox: rhobs/node_exporter
-      go-version: 1.19
+      go-version: "1.20"
       restore-downstream: >-
          OWNERS
       restore-upstream: >-

--- a/.github/workflows/merge-prom-label-proxy.yaml
+++ b/.github/workflows/merge-prom-label-proxy.yaml
@@ -11,7 +11,7 @@ jobs:
       upstream: prometheus-community/prom-label-proxy
       downstream: openshift/prom-label-proxy
       sandbox: rhobs/prom-label-proxy
-      go-version: 1.19
+      go-version: "1.20"
       restore-downstream: >-
          OWNERS
       restore-upstream: >-

--- a/.github/workflows/merge-prometheus.yaml
+++ b/.github/workflows/merge-prometheus.yaml
@@ -11,7 +11,7 @@ jobs:
       upstream: prometheus/prometheus
       downstream: openshift/prometheus
       sandbox: rhobs/prometheus
-      go-version: 1.19
+      go-version: "1.20"
       restore-upstream: >-
         CHANGELOG.md
         VERSION

--- a/.github/workflows/merge-thanos.yaml
+++ b/.github/workflows/merge-thanos.yaml
@@ -11,7 +11,7 @@ jobs:
       upstream: thanos-io/thanos
       downstream: openshift/thanos
       sandbox: rhobs/thanos
-      go-version: 1.19
+      go-version: "1.20"
       restore-upstream: >-
         CHANGELOG.md
         VERSION

--- a/.github/workflows/update-cmo-deps-versions.yaml
+++ b/.github/workflows/update-cmo-deps-versions.yaml
@@ -10,7 +10,7 @@ jobs:
   versions-update:
     uses: rhobs/syncbot/.github/workflows/cmo-make-targets.yaml@main
     with:
-      go-version: 1.19
+      go-version: "1.20"
       make-targets: versions generate
       pr-title: "[bot] Synchronize versions of the downstream components"
       pr-body: |

--- a/.github/workflows/update-cmo-jsonnet-deps.yaml
+++ b/.github/workflows/update-cmo-jsonnet-deps.yaml
@@ -8,7 +8,7 @@ jobs:
   jsonnet-update:
     uses: rhobs/syncbot/.github/workflows/cmo-make-targets.yaml@main
     with:
-      go-version: 1.19
+      go-version: "1.20"
       make-targets: update generate
       pr-title: "[bot] Update jsonnet dependencies"
       pr-body: |


### PR DESCRIPTION
* fallback to parsing a given raw manifest using the specified expression in case of `VERSION`'s absence
* remove `pozetroninc/github-action-get-latest-release` as it [failed to distinguish](https://github.com/rexagod/syncbot/actions/runs/5925561954/job/16065224002#step:4:3) between the latest release (tagged `latest`) and any other release that happened after that
* bump golang to 1.20

***

[Test run.](https://github.com/rexagod/syncbot/actions/runs/5926881264/job/16069170338#step:5:18)

***
/cc @simonpasquier @slashpai 