### PR TITLE
OCPBUGS-22687: prometheus: only compress assets if they have changed

### DIFF
--- a/.github/workflows/merge-prometheus.yaml
+++ b/.github/workflows/merge-prometheus.yaml
@@ -27,10 +27,15 @@ jobs:
         go.sum
         .golangci.yml
       assets-cmd: |
-        make assets-compress
-        find web/ui/static -type f -name '*.gz' -exec git add {} \;
-        git add web/ui/embed.go
-        git diff --cached --exit-code || git commit -s -m "[bot] assets: generate"
+        # Only compress assets if assets actually changed
+        # The git diff relies on gits remote naming. The merge-flow checks out
+        # $downstream as origin at the time of writing this code.
+        if ! git diff --exit-code origin/master web/ui; then
+          make assets-compress
+          find web/ui/static -type f -name '*.gz' -exec git add {} \;
+          git add web/ui/embed.go
+          git diff --cached --exit-code || git commit -s -m "[bot] assets: generate"
+        fi
 
     secrets:
       pr-app-id: ${{ secrets.APP_ID }}


### PR DESCRIPTION
Re-compressing the same assets will look like a change since the checksum of a zipped tar will change, even if the file content doesn't.