### PR TITLE
alertmanager: add asset-compress step

### DIFF
--- a/.github/workflows/merge-alertmanager.yaml
+++ b/.github/workflows/merge-alertmanager.yaml
@@ -26,6 +26,17 @@ jobs:
          VERSION
          go.mod
          go.sum
+      assets-cmd: |
+        # Only compress assets if assets actually changed
+        # The git diff relies on gits remote naming. The merge-flow checks out
+        # $downstream as origin at the time of writing this code.
+        if ! git diff --exit-code origin/master ui/react-app; then
+          make assets-compress
+          find ui/react-app -type f -name '*.gz' -exec git add {} \;
+          git add ui/react-app/embed.go
+          git diff --cached --exit-code || git commit -s -m "[bot] assets: generate"
+        fi
+
     secrets:
       pr-app-id: ${{ secrets.APP_ID }}
       pr-app-private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
To avoid manual intervention for alertmanager updates. See also https://github.com/openshift/prometheus-alertmanager/pull/90