### PR TITLE
feat: add a step to inject the VERSION file from the upstream tag ver…

### DIFF
--- a/.github/workflows/merge-flow.yaml
+++ b/.github/workflows/merge-flow.yaml
@@ -159,6 +159,22 @@ jobs:
       - name: Continue after merge conflict
         if: ${{ steps.merge.outputs.MERGE_CONFLICT == 'true' }}
         run: git merge --continue
+      - name: Add VERSION file if not present
+        run: |
+          # All tags use the vX.Y.Z format currently.
+          version_from_tag=$(echo ${{ steps.upstream.outputs.release }} | sed -e "s/^v//")
+          if [ -f VERSION ]; then
+            version_from_file=$(cat VERSION)
+            if [ "$version_from_tag" != "$version_from_file" ];then
+              echo "::error:: tag version ${version_from_tag} doesn't correspond to version ${version_from_file} from VERSION file"
+              exit 1
+            fi
+            echo "::notice::VERSION file already present"
+            exit 0
+          fi
+          echo "$version_from_tag" > VERSION
+          git add VERSION
+          git diff --cached --exit-code || git commit -s -m "[bot] add VERSION file with ${version_from_tag}"
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ inputs.go-version }}


### PR DESCRIPTION
…sion

From https://github.com/openshift/cluster-monitoring-operator/pull/2252#discussion_r1474211363

- upstream `metrics-server` doesn't/cannot provide a VERSION file
- maybe some other upstream repos will drop it.
- It's less error prone to use the tag as it's easy to become outdated upstream.