### PR TITLE
chore(alertmanager): bump to go 1.22

### DIFF
--- a/.github/workflows/merge-alertmanager.yaml
+++ b/.github/workflows/merge-alertmanager.yaml
@@ -20,7 +20,7 @@ jobs:
       upstream: prometheus/alertmanager
       downstream: openshift/prometheus-alertmanager
       sandbox: rhobs/prometheus-alertmanager
-      go-version: "1.21"
+      go-version: "1.22"
       restore-upstream: >-
          CHANGELOG.md
          VERSION


### PR DESCRIPTION
see https://github.com/openshift/prometheus-alertmanager/pull/93