### PR TITLE
Add Alertmanager workflow and additional step to update PR

### DIFF
--- a/.github/workflows/merge-acm-alertmanager.yaml
+++ b/.github/workflows/merge-acm-alertmanager.yaml
@@ -1,4 +1,4 @@
-name: ACM Prometheus merger
+name: ACM Alertmanager merger
 
 on:
   workflow_dispatch:
@@ -6,34 +6,34 @@ on:
     - cron: '0 0 * * 1' #@weekly
   pull_request:
     paths:
-    - '.github/workflows/merge-acm-flow.yaml'
-    - '.github/workflows/merge-acm-prometheus.yaml'
+      - '.github/workflows/merge-acm-flow.yaml'
+      - '.github/workflows/merge-acm-alertmanager.yaml'
   push:
     paths:
-    - '.github/workflows/merge-acm-flow.yaml'
-    - '.github/workflows/merge-acm-prometheus.yaml'
+      - '.github/workflows/merge-acm-flow.yaml'
+      - '.github/workflows/merge-acm-alertmanager.yaml'
+
 jobs:
-  acm-prometheus-merge:
+  alertmanager-merge:
     uses: ./.github/workflows/merge-acm-flow.yaml
     with:
-      upstream: prometheus/prometheus
-      downstream: stolostron/prometheus
-      sandbox: rhobs/acm-prometheus
-      go-version: "1.21"
+      upstream: prometheus/alertmanager
+      downstream: stolostron/prometheus-alertmanager
+      sandbox: rhobs/acm-prometheus-alertmanager
+      go-version: "1.22"
       restore-upstream: >-
         CHANGELOG.md
         VERSION
         go.mod
         go.sum
-        .golangci.yml
       assets-cmd: |
         # Only compress assets if assets actually changed
         # The git diff relies on gits remote naming. The merge-flow checks out
         # $downstream as origin at the time of writing this code.
-        if ! git diff --exit-code origin/main web/ui; then
+        if ! git diff --exit-code origin/master ui/react-app; then
           make assets-compress
-          find web/ui/static -type f -name '*.gz' -exec git add -f {} \;
-          git add -f web/ui/embed.go
+          find ui/react-app -type f -name '*.gz' -exec git add {} \;
+          git add ui/react-app/embed.go
           git diff --cached --exit-code || git commit -s -m "[bot] assets: generate"
         fi
 

--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -272,7 +272,7 @@ jobs:
           if [ ${{ steps.pr-exists.outputs.pr_exists }} != '1' ] || [ ${{ steps.fork-sync.outputs.status }} == "uptodate" ] || [ ${{ steps.fork-sync.outputs.status }} == "ahead" ] ; then
             echo "message=${{ inputs.downstream }} is already ${{ steps.fork-sync.outputs.status }} with tag ${{ steps.org.outputs.downstream-version }}." >> $GITHUB_OUTPUT
           else
-            echo "message=PR ${{ steps.pr-exists.outputs.pr_url }} has been updated." >> $GITHUB_OUTPUT
+            echo "message=PR ${{ steps.create-pr.outputs.pull-request-url }} || ${{ steps.pr-exists.output.pr_url }} has been ${{ steps.create-pr.outputs.pull-request-operation || 'updated' }}." >> $GITHUB_OUTPUT
           fi
       - uses: 8398a7/action-slack@v3
         if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead' || steps.pr-exists.outputs.pr_exists == '1')

--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -256,7 +256,7 @@ jobs:
             --head automated-updates-acm-${{ inputs.downstream-branch }} \
             --repo ${{ inputs.sandbox }}
           env:
-            GITHUB_TOKEN: ${{ steps.pr.outputs.token }}
+            GH_TOKEN: ${{ steps.pr.outputs.token }}
       - name: Compose slack message body
         if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead')
         continue-on-error: true

--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -108,7 +108,7 @@ jobs:
           version: ${{ steps.org.outputs.downstream-version }}
           compare-to: ${{ steps.upstream.outputs.release }}
           lenient: false # fail if either of the versions cannot be parsed
-      - name: Check openshift fork status
+      - name: Check ACM stolostron fork status
         id: fork-sync
         run: |
           SEMVER_RESULT="${{ steps.version.outputs.comparison-result }}"

--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -272,7 +272,7 @@ jobs:
           if [ ${{ steps.pr-exists.outputs.pr_exists }} != '1' ] || [ ${{ steps.fork-sync.outputs.status }} == "uptodate" ] || [ ${{ steps.fork-sync.outputs.status }} == "ahead" ] ; then
             echo "message=${{ inputs.downstream }} is already ${{ steps.fork-sync.outputs.status }} with tag ${{ steps.org.outputs.downstream-version }}." >> $GITHUB_OUTPUT
           else
-            echo "message=PR ${{ steps.create-pr.outputs.pull-request-url }} || ${{ steps.pr-exists.output.pr_url }} has been ${{ steps.create-pr.outputs.pull-request-operation || 'updated' }}." >> $GITHUB_OUTPUT
+            echo "message=PR ${{ steps.create-pr.outputs.pull-request-url }} || ${{ steps.pr-exists.outputs.pr_url }} has been ${{ steps.create-pr.outputs.pull-request-operation || 'updated' }}." >> $GITHUB_OUTPUT
           fi
       - uses: 8398a7/action-slack@v3
         if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead' || steps.pr-exists.outputs.pr_exists == '1')

--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -242,9 +242,9 @@ jobs:
           signoff: true
           branch: automated-updates-acm-${{ inputs.downstream-branch }}
           delete-branch: true
-          token: ${{ steps.cloner.outputs.token }}
+          token: ${{ steps.pr.outputs.token }}
           push-to-fork: ${{ inputs.sandbox }}
-#          push-to-fork-token: ${{ steps.cloner.outputs.token }}
+          push-to-fork-token: ${{ steps.cloner.outputs.token }}
       # - name: Create Pull Request using GitHub CLI
       #   id: create-pr
       #   if: github.event_name != 'pull_request'

--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -211,7 +211,7 @@ jobs:
           scope: ${{ steps.org.outputs.sandbox }}
       - name: Create Pull Request
         if: github.event_name != 'pull_request'
-        uses: rhobs/create-pull-request@v3
+        uses: rhobs/create-pull-request@coleenquadros-patch-2
         id: create-pr
         with:
           title: "[bot] Bump ${{ inputs.downstream }} to ${{ steps.upstream.outputs.release }}"

--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -209,64 +209,64 @@ jobs:
           app_id: ${{ secrets.cloner-app-id }}
           private_key: ${{ secrets.cloner-app-private-key }}
           scope: ${{ steps.org.outputs.sandbox }}
-#      - name: Create Pull Request
-#        if: github.event_name != 'pull_request'
-#        uses: rhobs/create-pull-request@v3
-#        id: create-pr
-#        with:
-#          title: "[bot] Bump ${{ inputs.downstream }} to ${{ steps.upstream.outputs.release }}"
-#          body: |
-#            ## Description
-#            This is an automated version bump from CI.
-#            The logs for this run can be found [in the syncbot repo actions](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
-#            If you wish to perform this manually, execute the following commands from ${{ inputs.downstream }} repo:
-#            ```
-#            git fetch https://github.com/${{ inputs.upstream }} --tags
-#            if ! git merge refs/tags/${{ steps.upstream.outputs.release }} --no-edit; then
-#              git checkout --theirs ${{ inputs.restore-upstream }}
-#              git checkout --ours ${{ inputs.restore-downstream }}
-#              git add ${{ inputs.restore-upstream }} ${{ inputs.restore-downstream }}
-#              git merge --continue
-#            fi
-#            go mod tidy
-#            go mod vendor
-#            ${{ inputs.assets-cmd }}
-#            if [ -f scripts/rh-manifest.sh ]; then
-#              bash scripts/rh-manifest.sh
-#              git add rh-manifest.txt
-#              git diff --cached --exit-code || git commit -s -m "[bot] update rh-manifest.txt"
-#            fi
-#            ```
-#          author: 'github-actions[bot]<github-actions[bot]@users.noreply.github.com>'
-#          committer: 'github-actions[bot]<github-actions[bot]@users.noreply.github.com>'
-#          signoff: true
-#          branch: automated-updates-acm-${{ inputs.downstream-branch }}
-#          delete-branch: true
-#          token: ${{ steps.pr.outputs.token }}
-#          push-to-fork: ${{ inputs.sandbox }}
-#          push-to-fork-token: ${{ steps.cloner.outputs.token }}
-      - name: Create Pull Request using GitHub CLI
-        id: create-pr
-        if: github.event_name != 'pull_request'
-        run: |
-          gh pr create \
-            --title "[bot] Bump ${{ inputs.downstream }} to ${{ steps.upstream.outputs.release }}" \
-            --body "test PR creation with syncbot" \
-            --base ${{ inputs.downstream-branch }} \
-            --head automated-updates-acm-${{ inputs.downstream-branch }} \
-            --repo ${{ inputs.downstream }}
-        env:
-            GH_TOKEN: ${{ steps.pr.outputs.token }}
-      - name: Compose slack message body
-        if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead')
-        continue-on-error: true
-        id: slack-message
-        run: |
-          if [ "${{ steps.create-pr.outputs.pull-request-url }}" == "" ] || [ ${{ steps.fork-sync.outputs.status }} == "uptodate" ] || [ ${{ steps.fork-sync.outputs.status }} == "ahead" ] ; then
-            echo "message=${{ inputs.downstream }} is already ${{ steps.fork-sync.outputs.status }} with tag ${{ steps.org.outputs.downstream-version }}." >> $GITHUB_OUTPUT
-          else
-            echo "message=PR ${{ steps.create-pr.outputs.pull-request-url }} has been ${{ steps.create-pr.outputs.pull-request-operation || 'updated' }}." >> $GITHUB_OUTPUT
-          fi
+     - name: Create Pull Request
+       if: github.event_name != 'pull_request'
+       uses: rhobs/create-pull-request@v3
+       id: create-pr
+       with:
+         title: "[bot] Bump ${{ inputs.downstream }} to ${{ steps.upstream.outputs.release }}"
+         body: |
+           ## Description
+           This is an automated version bump from CI.
+           The logs for this run can be found [in the syncbot repo actions](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+           If you wish to perform this manually, execute the following commands from ${{ inputs.downstream }} repo:
+           ```
+           git fetch https://github.com/${{ inputs.upstream }} --tags
+           if ! git merge refs/tags/${{ steps.upstream.outputs.release }} --no-edit; then
+             git checkout --theirs ${{ inputs.restore-upstream }}
+             git checkout --ours ${{ inputs.restore-downstream }}
+             git add ${{ inputs.restore-upstream }} ${{ inputs.restore-downstream }}
+             git merge --continue
+           fi
+           go mod tidy
+           go mod vendor
+           ${{ inputs.assets-cmd }}
+           if [ -f scripts/rh-manifest.sh ]; then
+             bash scripts/rh-manifest.sh
+             git add rh-manifest.txt
+             git diff --cached --exit-code || git commit -s -m "[bot] update rh-manifest.txt"
+           fi
+           ```
+         author: 'github-actions[bot]<github-actions[bot]@users.noreply.github.com>'
+         committer: 'github-actions[bot]<github-actions[bot]@users.noreply.github.com>'
+         signoff: true
+         branch: acm-prometheus:automated-updates-acm-${{ inputs.downstream-branch }}
+         delete-branch: true
+         token: ${{ steps.pr.outputs.token }}
+         push-to-fork: ${{ inputs.sandbox }}
+         push-to-fork-token: ${{ steps.cloner.outputs.token }}
+      # - name: Create Pull Request using GitHub CLI
+      #   id: create-pr
+      #   if: github.event_name != 'pull_request'
+      #   run: |
+      #     gh pr create \
+      #       --title "[bot] Bump ${{ inputs.downstream }} to ${{ steps.upstream.outputs.release }}" \
+      #       --body "test PR creation with syncbot" \
+      #       --base ${{ inputs.downstream-branch }} \
+      #       --head automated-updates-acm-${{ inputs.downstream-branch }} \
+      #       --repo ${{ inputs.downstream }}
+      #   env:
+      #       GH_TOKEN: ${{ steps.pr.outputs.token }}
+      # - name: Compose slack message body
+      #   if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead')
+      #   continue-on-error: true
+      #   id: slack-message
+      #   run: |
+      #     if [ "${{ steps.create-pr.outputs.pull-request-url }}" == "" ] || [ ${{ steps.fork-sync.outputs.status }} == "uptodate" ] || [ ${{ steps.fork-sync.outputs.status }} == "ahead" ] ; then
+      #       echo "message=${{ inputs.downstream }} is already ${{ steps.fork-sync.outputs.status }} with tag ${{ steps.org.outputs.downstream-version }}." >> $GITHUB_OUTPUT
+      #     else
+      #       echo "message=PR ${{ steps.create-pr.outputs.pull-request-url }} has been ${{ steps.create-pr.outputs.pull-request-operation || 'updated' }}." >> $GITHUB_OUTPUT
+      #     fi
       - uses: 8398a7/action-slack@v3
         if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead')
         continue-on-error: true

--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -211,7 +211,7 @@ jobs:
           scope: ${{ steps.org.outputs.sandbox }}
       - name: Create Pull Request
         if: github.event_name != 'pull_request'
-        uses: rhobs/create-pull-request@coleenquadros-patch-2
+        uses: rhobs/acm-create-pull-request@push-to-fork-token
         id: create-pr
         with:
           title: "[bot] Bump ${{ inputs.downstream }} to ${{ steps.upstream.outputs.release }}"

--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -254,7 +254,7 @@ jobs:
             --body "test PR creation with syncbot" \
             --base ${{ inputs.downstream-branch }} \
             --head automated-updates-acm-${{ inputs.downstream-branch }} \
-            --repo ${{ inputs.sandbox }}
+            --repo ${{ inputs.downstream }}
         env:
             GH_TOKEN: ${{ steps.pr.outputs.token }}
       - name: Compose slack message body

--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -252,7 +252,6 @@ jobs:
           gh pr create \
             --title "[bot] Bump ${{ inputs.downstream }} to ${{ steps.upstream.outputs.release }}" \
             --body "test PR creation with syncbot" \
-            --author "github-actions[bot]<github-actions[bot]@users.noreply.github.com>" \
             --base ${{ inputs.downstream-branch }} \
             --head automated-updates-acm-${{ inputs.downstream-branch }} \
             --repo ${{ inputs.sandbox }}

--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -246,7 +246,7 @@ jobs:
           push-to-fork: ${{ inputs.sandbox }}
           push-to-fork-token: ${{ steps.cloner.outputs.token }}
       - name: Compose slack message body
-        if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead' || || contains(steps.create_pr.outputs.output, 'A pull request already exists'))
+        if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead' || contains(steps.create_pr.outputs.output, 'A pull request already exists'))
         continue-on-error: true
         id: slack-message
         run: |

--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -214,7 +214,7 @@ jobs:
         uses: rhobs/acm-create-pull-request@push-to-fork-token
         id: create-pr
         with:
-          title: "[bot] Bump ${{ inputs.downstream }} to ${{ steps.upstream.outputs.release }}"
+          title: "[ACM Obs bot] Bump ${{ inputs.downstream }} to ${{ steps.upstream.outputs.release }}"
           body: |
             ## Description
             This is an automated version bump from CI.
@@ -245,18 +245,37 @@ jobs:
           token: ${{ steps.pr.outputs.token }}
           push-to-fork: ${{ inputs.sandbox }}
           push-to-fork-token: ${{ steps.cloner.outputs.token }}
+      - name: Check if PR exists using gh cli
+        # This step is a hack for the time being as the create-pull-request action has an issue with listing PRs across different named forks of the same repo.
+        # This is only to get the PR URL if it exists.
+        if: github.event_name != 'pull_request' && failure()
+        id: pr-exists
+        env:
+          GH_TOKEN: ${{ steps.pr.outputs.token }}
+        run: |
+          if [ "${{ steps.create-pr.outcome }}" != "success" ]; then
+            echo "${{ steps.create-pr.outcome }}"
+            PR_URL=$(gh pr list --json url --jq '.[0].url' --repo ${{ inputs.downstream }} --state open  --head automated-updates-acm-${{ inputs.downstream-branch }})
+              if [ ! -z "$PR_URL" ]; then
+                echo "pr_exists=1" >> $GITHUB_OUTPUT
+                echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+                echo "PR exists >>  $PR_URL"
+              else
+                echo "pr_exists=0" >> $GITHUB_OUTPUT
+              fi
+          fi
       - name: Compose slack message body
-        if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead' || contains(steps.create_pr.outputs.output, 'A pull request already exists'))
+        if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead' || steps.pr-exists.outputs.pr_exists == '1' )
         continue-on-error: true
         id: slack-message
         run: |
-          if [ "${{ steps.create-pr.outputs.pull-request-url }}" == "" ] || [ ${{ steps.fork-sync.outputs.status }} == "uptodate" ] || [ ${{ steps.fork-sync.outputs.status }} == "ahead" ] ; then
+          if [ ${{ steps.pr-exists.outputs.pr_exists }} != '1' ] || [ ${{ steps.fork-sync.outputs.status }} == "uptodate" ] || [ ${{ steps.fork-sync.outputs.status }} == "ahead" ] ; then
             echo "message=${{ inputs.downstream }} is already ${{ steps.fork-sync.outputs.status }} with tag ${{ steps.org.outputs.downstream-version }}." >> $GITHUB_OUTPUT
           else
-            echo "message=PR ${{ steps.create-pr.outputs.pull-request-url }} has been ${{ steps.create-pr.outputs.pull-request-operation || 'updated' }}." >> $GITHUB_OUTPUT
+            echo "message=PR ${{ steps.pr-exists.outputs.pr_url }} has been updated." >> $GITHUB_OUTPUT
           fi
       - uses: 8398a7/action-slack@v3
-        if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead' || contains(steps.create_pr.outputs.output, 'A pull request already exists'))
+        if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead' || steps.pr-exists.outputs.pr_exists == '1')
         continue-on-error: true
         with:
           status: custom
@@ -271,7 +290,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.slack-webhook-url }}
       - uses: 8398a7/action-slack@v3
-        if: github.event_name != 'pull_request' && (failure() && steps.fork-sync.outputs.status != 'uptodate' && steps.fork-sync.outputs.status != 'ahead' && !contains(steps.create_pr.outputs.output, 'A pull request already exists'))
+        if: github.event_name != 'pull_request' && (failure() && steps.fork-sync.outputs.status != 'uptodate' && steps.fork-sync.outputs.status != 'ahead' && !(steps.pr-exists.outputs.pr_exists == '1'))
         continue-on-error: true
         with:
           status: custom

--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -209,42 +209,42 @@ jobs:
           app_id: ${{ secrets.cloner-app-id }}
           private_key: ${{ secrets.cloner-app-private-key }}
           scope: ${{ steps.org.outputs.sandbox }}
-     - name: Create Pull Request
-       if: github.event_name != 'pull_request'
-       uses: rhobs/create-pull-request@v3
-       id: create-pr
-       with:
-         title: "[bot] Bump ${{ inputs.downstream }} to ${{ steps.upstream.outputs.release }}"
-         body: |
-           ## Description
-           This is an automated version bump from CI.
-           The logs for this run can be found [in the syncbot repo actions](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
-           If you wish to perform this manually, execute the following commands from ${{ inputs.downstream }} repo:
-           ```
-           git fetch https://github.com/${{ inputs.upstream }} --tags
-           if ! git merge refs/tags/${{ steps.upstream.outputs.release }} --no-edit; then
-             git checkout --theirs ${{ inputs.restore-upstream }}
-             git checkout --ours ${{ inputs.restore-downstream }}
-             git add ${{ inputs.restore-upstream }} ${{ inputs.restore-downstream }}
-             git merge --continue
-           fi
-           go mod tidy
-           go mod vendor
-           ${{ inputs.assets-cmd }}
-           if [ -f scripts/rh-manifest.sh ]; then
-             bash scripts/rh-manifest.sh
-             git add rh-manifest.txt
-             git diff --cached --exit-code || git commit -s -m "[bot] update rh-manifest.txt"
-           fi
-           ```
-         author: 'github-actions[bot]<github-actions[bot]@users.noreply.github.com>'
-         committer: 'github-actions[bot]<github-actions[bot]@users.noreply.github.com>'
-         signoff: true
-         branch: acm-prometheus:automated-updates-acm-${{ inputs.downstream-branch }}
-         delete-branch: true
-         token: ${{ steps.pr.outputs.token }}
-         push-to-fork: ${{ inputs.sandbox }}
-         push-to-fork-token: ${{ steps.cloner.outputs.token }}
+      - name: Create Pull Request
+        if: github.event_name != 'pull_request'
+        uses: rhobs/create-pull-request@v3
+        id: create-pr
+        with:
+          title: "[bot] Bump ${{ inputs.downstream }} to ${{ steps.upstream.outputs.release }}"
+          body: |
+            ## Description
+            This is an automated version bump from CI.
+            The logs for this run can be found [in the syncbot repo actions](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+            If you wish to perform this manually, execute the following commands from ${{ inputs.downstream }} repo:
+            ```
+             git fetch https://github.com/${{ inputs.upstream }} --tags
+             if ! git merge refs/tags/${{ steps.upstream.outputs.release }} --no-edit; then
+               git checkout --theirs ${{ inputs.restore-upstream }}
+               git checkout --ours ${{ inputs.restore-downstream }}
+               git add ${{ inputs.restore-upstream }} ${{ inputs.restore-downstream }}
+               git merge --continue
+             fi
+             go mod tidy
+             go mod vendor
+             ${{ inputs.assets-cmd }}
+             if [ -f scripts/rh-manifest.sh ]; then
+               bash scripts/rh-manifest.sh
+               git add rh-manifest.txt
+               git diff --cached --exit-code || git commit -s -m "[bot] update rh-manifest.txt"
+             fi
+             ```
+          author: 'github-actions[bot]<github-actions[bot]@users.noreply.github.com>'
+          committer: 'github-actions[bot]<github-actions[bot]@users.noreply.github.com>'
+          signoff: true
+          branch: acm-prometheus:automated-updates-acm-${{ inputs.downstream-branch }}
+          delete-branch: true
+          token: ${{ steps.pr.outputs.token }}
+          push-to-fork: ${{ inputs.sandbox }}
+          push-to-fork-token: ${{ steps.cloner.outputs.token }}
       # - name: Create Pull Request using GitHub CLI
       #   id: create-pr
       #   if: github.event_name != 'pull_request'

--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -196,7 +196,7 @@ jobs:
       - name: Get auth token to create pull request for ${{ inputs.downstream }}
         if: github.event_name != 'pull_request'
         id: pr
-        uses: getsentry/action-github-app-token@v1
+        uses: getsentry/action-github-app-token@v3
         with:
           app_id: ${{ secrets.pr-app-id }}
           private_key: ${{ secrets.pr-app-private-key }}
@@ -204,7 +204,7 @@ jobs:
       - name: Get auth token to push to ${{ inputs.sandbox }}
         if: github.event_name != 'pull_request'
         id: cloner
-        uses: getsentry/action-github-app-token@v1
+        uses: getsentry/action-github-app-token@v3
         with:
           app_id: ${{ secrets.cloner-app-id }}
           private_key: ${{ secrets.cloner-app-private-key }}

--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -255,7 +255,7 @@ jobs:
             --base ${{ inputs.downstream-branch }} \
             --head automated-updates-acm-${{ inputs.downstream-branch }} \
             --repo ${{ inputs.sandbox }}
-          env:
+        env:
             GH_TOKEN: ${{ steps.pr.outputs.token }}
       - name: Compose slack message body
         if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead')

--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -269,10 +269,15 @@ jobs:
         continue-on-error: true
         id: slack-message
         run: |
-          if [ ${{ steps.pr-exists.outputs.pr_exists }} != '1' ] || [ ${{ steps.fork-sync.outputs.status }} == "uptodate" ] || [ ${{ steps.fork-sync.outputs.status }} == "ahead" ] ; then
+          if [ "${{ steps.pr-exists.outputs.pr_exists }}" == "1" ]; then
+            PR_URL="${{ steps.pr-exists.outputs.pr_url }}"
+          else
+            PR_URL="${{ steps.create-pr.outputs.pull-request-url }}"
+          fi
+          if [ "${{ steps.fork-sync.outputs.status }}" == "uptodate" ] || [ "${{ steps.fork-sync.outputs.status }}" == "ahead" ]; then
             echo "message=${{ inputs.downstream }} is already ${{ steps.fork-sync.outputs.status }} with tag ${{ steps.org.outputs.downstream-version }}." >> $GITHUB_OUTPUT
           else
-            echo "message=PR ${{ steps.create-pr.outputs.pull-request-url }} || ${{ steps.pr-exists.outputs.pr_url }} has been ${{ steps.create-pr.outputs.pull-request-operation || 'updated' }}." >> $GITHUB_OUTPUT
+            echo "message=PR $PR_URL has been ${{ steps.create-pr.outputs.pull-request-operation || 'updated' }}." >> $GITHUB_OUTPUT
           fi
       - uses: 8398a7/action-slack@v3
         if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead' || steps.pr-exists.outputs.pr_exists == '1')

--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -211,7 +211,7 @@ jobs:
           scope: ${{ steps.org.outputs.sandbox }}
       - name: Create Pull Request
         if: github.event_name != 'pull_request'
-        uses: peter-evans/create-pull-request@v6
+        uses: rhobs/create-pull-request@v3
         id: create-pr
         with:
           title: "[bot] Bump ${{ inputs.downstream }} to ${{ steps.upstream.outputs.release }}"

--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -257,16 +257,16 @@ jobs:
       #       --repo ${{ inputs.downstream }}
       #   env:
       #       GH_TOKEN: ${{ steps.pr.outputs.token }}
-      # - name: Compose slack message body
-      #   if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead')
-      #   continue-on-error: true
-      #   id: slack-message
-      #   run: |
-      #     if [ "${{ steps.create-pr.outputs.pull-request-url }}" == "" ] || [ ${{ steps.fork-sync.outputs.status }} == "uptodate" ] || [ ${{ steps.fork-sync.outputs.status }} == "ahead" ] ; then
-      #       echo "message=${{ inputs.downstream }} is already ${{ steps.fork-sync.outputs.status }} with tag ${{ steps.org.outputs.downstream-version }}." >> $GITHUB_OUTPUT
-      #     else
-      #       echo "message=PR ${{ steps.create-pr.outputs.pull-request-url }} has been ${{ steps.create-pr.outputs.pull-request-operation || 'updated' }}." >> $GITHUB_OUTPUT
-      #     fi
+      - name: Compose slack message body
+        if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead')
+        continue-on-error: true
+        id: slack-message
+        run: |
+          if [ "${{ steps.create-pr.outputs.pull-request-url }}" == "" ] || [ ${{ steps.fork-sync.outputs.status }} == "uptodate" ] || [ ${{ steps.fork-sync.outputs.status }} == "ahead" ] ; then
+            echo "message=${{ inputs.downstream }} is already ${{ steps.fork-sync.outputs.status }} with tag ${{ steps.org.outputs.downstream-version }}." >> $GITHUB_OUTPUT
+          else
+            echo "message=PR ${{ steps.create-pr.outputs.pull-request-url }} has been ${{ steps.create-pr.outputs.pull-request-operation || 'updated' }}." >> $GITHUB_OUTPUT
+          fi
       - uses: 8398a7/action-slack@v3
         if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead')
         continue-on-error: true

--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -251,27 +251,7 @@ jobs:
         run: |
           gh pr create \
             --title "[bot] Bump ${{ inputs.downstream }} to ${{ steps.upstream.outputs.release }}" \
-            --body "## Description
-            This is an automated version bump from CI.
-            The logs for this run can be found [in the syncbot repo actions](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
-            If you wish to perform this manually, execute the following commands from ${{ inputs.downstream }} repo:
-            ```
-            git fetch https://github.com/${{ inputs.upstream }} --tags
-            if ! git merge refs/tags/${{ steps.upstream.outputs.release }} --no-edit; then
-              git checkout --theirs ${{ inputs.restore-upstream }}
-              git checkout --ours ${{ inputs.restore-downstream }}
-              git add ${{ inputs.restore-upstream }} ${{ inputs.restore-downstream }}
-              git merge --continue
-            fi
-            go mod tidy
-            go mod vendor
-            ${{ inputs.assets-cmd }}
-            if [ -f scripts/rh-manifest.sh ]; then
-              bash scripts/rh-manifest.sh
-              git add rh-manifest.txt
-              git diff --cached --exit-code || git commit -s -m "[bot] update rh-manifest.txt"
-            fi
-            ```" \
+            --body "test PR creation with syncbot" \
             --author "github-actions[bot]<github-actions[bot]@users.noreply.github.com>" \
             --base ${{ inputs.downstream-branch }} \
             --head automated-updates-acm-${{ inputs.downstream-branch }} \

--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -246,7 +246,7 @@ jobs:
           push-to-fork: ${{ inputs.sandbox }}
           push-to-fork-token: ${{ steps.cloner.outputs.token }}
       - name: Compose slack message body
-        if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead')
+        if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead' || || contains(steps.create_pr.outputs.output, 'A pull request already exists'))
         continue-on-error: true
         id: slack-message
         run: |
@@ -256,7 +256,7 @@ jobs:
             echo "message=PR ${{ steps.create-pr.outputs.pull-request-url }} has been ${{ steps.create-pr.outputs.pull-request-operation || 'updated' }}." >> $GITHUB_OUTPUT
           fi
       - uses: 8398a7/action-slack@v3
-        if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead')
+        if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead' || contains(steps.create_pr.outputs.output, 'A pull request already exists'))
         continue-on-error: true
         with:
           status: custom
@@ -271,7 +271,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.slack-webhook-url }}
       - uses: 8398a7/action-slack@v3
-        if: github.event_name != 'pull_request' && (failure() && steps.fork-sync.outputs.status != 'uptodate' && steps.fork-sync.outputs.status != 'ahead')
+        if: github.event_name != 'pull_request' && (failure() && steps.fork-sync.outputs.status != 'uptodate' && steps.fork-sync.outputs.status != 'ahead' && !contains(steps.create_pr.outputs.output, 'A pull request already exists'))
         continue-on-error: true
         with:
           status: custom

--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -245,18 +245,6 @@ jobs:
           token: ${{ steps.pr.outputs.token }}
           push-to-fork: ${{ inputs.sandbox }}
           push-to-fork-token: ${{ steps.cloner.outputs.token }}
-      # - name: Create Pull Request using GitHub CLI
-      #   id: create-pr
-      #   if: github.event_name != 'pull_request'
-      #   run: |
-      #     gh pr create \
-      #       --title "[bot] Bump ${{ inputs.downstream }} to ${{ steps.upstream.outputs.release }}" \
-      #       --body "test PR creation with syncbot" \
-      #       --base ${{ inputs.downstream-branch }} \
-      #       --head automated-updates-acm-${{ inputs.downstream-branch }} \
-      #       --repo ${{ inputs.downstream }}
-      #   env:
-      #       GH_TOKEN: ${{ steps.pr.outputs.token }}
       - name: Compose slack message body
         if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead')
         continue-on-error: true

--- a/.github/workflows/merge-acm-kube-state-metrics.yaml
+++ b/.github/workflows/merge-acm-kube-state-metrics.yaml
@@ -21,7 +21,9 @@ jobs:
       downstream: stolostron/kube-state-metrics
       sandbox: rhobs/acm-kube-state-metrics
       go-version: "1.21"
-      restore-upstream: CHANGELOG.md VERSION
+      restore-upstream: >-
+        CHANGELOG.md 
+        VERSION
       restore-downstream: >-
         OWNERS
         docs

--- a/.github/workflows/merge-acm-kube-state-metrics.yaml
+++ b/.github/workflows/merge-acm-kube-state-metrics.yaml
@@ -1,4 +1,4 @@
-name: kube-state-metrics merger
+name: ACM kube-state-metrics merger
 
 on:
   workflow_dispatch:

--- a/.github/workflows/merge-acm-kube-state-metrics.yaml
+++ b/.github/workflows/merge-acm-kube-state-metrics.yaml
@@ -1,0 +1,31 @@
+name: kube-state-metrics merger
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 1' #@weekly
+  pull_request:
+    paths:
+    - '.github/workflows/merge-acm-flow.yaml'
+    - '.github/workflows/merge-acm-kube-state-metrics.yaml'
+  push:
+    paths:
+    - '.github/workflows/merge-acm-flow.yaml'
+    - '.github/workflows/merge-acm-kube-state-metrics.yaml'
+
+jobs:
+  kube-state-metrics-merge:
+    uses: ./.github/workflows/merge-acm-flow.yaml
+    with:
+      upstream: kubernetes/kube-state-metrics
+      downstream: stolostron/kube-state-metrics
+      sandbox: rhobs/acm-kube-state-metrics
+      go-version: "1.21"
+      restore-upstream: CHANGELOG.md VERSION
+      restore-downstream: OWNERS
+    secrets:
+      pr-app-id: ${{ secrets.ACM_APP_ID }}
+      pr-app-private-key: ${{ secrets.ACM_APP_PRIVATE_KEY }}
+      cloner-app-id: ${{ secrets.ACM_CLONER_APP_ID }}
+      cloner-app-private-key: ${{ secrets.ACM_CLONER_APP_PRIVATE_KEY }}
+      slack-webhook-url: ${{ secrets.ACM_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/merge-acm-kube-state-metrics.yaml
+++ b/.github/workflows/merge-acm-kube-state-metrics.yaml
@@ -22,7 +22,9 @@ jobs:
       sandbox: rhobs/acm-kube-state-metrics
       go-version: "1.21"
       restore-upstream: CHANGELOG.md VERSION
-      restore-downstream: OWNERS
+      restore-downstream: >-
+        OWNERS
+        docs
     secrets:
       pr-app-id: ${{ secrets.ACM_APP_ID }}
       pr-app-private-key: ${{ secrets.ACM_APP_PRIVATE_KEY }}

--- a/.github/workflows/merge-acm-node-exporter.yaml
+++ b/.github/workflows/merge-acm-node-exporter.yaml
@@ -1,4 +1,4 @@
-name: Node exporter merger
+name: ACM Node exporter merger
 
 on:
   workflow_dispatch:

--- a/.github/workflows/merge-acm-node-exporter.yaml
+++ b/.github/workflows/merge-acm-node-exporter.yaml
@@ -16,7 +16,7 @@ jobs:
   node-exporter-merge:
     uses: ./.github/workflows/merge-acm-flow.yaml
     with:
-      upstream: prometheus/node-exporter
+      upstream: prometheus/node_exporter
       downstream: stolostron/node-exporter
       sandbox: rhobs/acm-node-exporter
       go-version: "1.21"

--- a/.github/workflows/merge-acm-node-exporter.yaml
+++ b/.github/workflows/merge-acm-node-exporter.yaml
@@ -1,0 +1,36 @@
+name: Node exporter merger
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 1' #@weekly
+  pull_request:
+    paths:
+    - '.github/workflows/merge-acm-flow.yaml'
+    - '.github/workflows/merge-acm-node-exporter.yaml'
+  push:
+    paths:
+    - '.github/workflows/merge-acm-flow.yaml'
+    - '.github/workflows/merge-acm-node-exporter.yaml'
+jobs:
+  node-exporter-merge:
+    uses: ./.github/workflows/merge-acm-flow.yaml
+    with:
+      upstream: prometheus/node-exporter
+      downstream: stolostron/node-exporter
+      sandbox: rhobs/acm-node-exporter
+      go-version: "1.21"
+      restore-downstream: >-
+         OWNERS
+      restore-upstream: >-
+         CHANGELOG.md
+         VERSION
+         collector
+         go.mod
+         go.sum
+    secrets:
+      pr-app-id: ${{ secrets.ACM_APP_ID }}
+      pr-app-private-key: ${{ secrets.ACM_APP_PRIVATE_KEY }}
+      cloner-app-id: ${{ secrets.ACM_CLONER_APP_ID }}
+      cloner-app-private-key: ${{ secrets.ACM_CLONER_APP_PRIVATE_KEY }}
+      slack-webhook-url: ${{ secrets.ACM_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/merge-acm-prometheus-operator.yaml
+++ b/.github/workflows/merge-acm-prometheus-operator.yaml
@@ -3,7 +3,7 @@ name: ACM Prometheus Operator merger
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *' #@daily
+    - cron: '0 0 * * 1' #@weekly
   pull_request:
     paths:
     - '.github/workflows/merge-acm-flow.yaml'

--- a/.github/workflows/merge-acm-prometheus-operator.yaml
+++ b/.github/workflows/merge-acm-prometheus-operator.yaml
@@ -2,16 +2,16 @@ name: ACM Prometheus Operator merger
 
 on:
   workflow_dispatch:
-#  schedule:
-#    - cron: '0 0 * * *' #@daily
-#  pull_request:
-#    paths:
-#    - '.github/workflows/merge-acm-flow.yaml'
-#    - '.github/workflows/merge-acm-prometheus-operator.yaml'
-#  push:
-#    paths:
-#    - '.github/workflows/merge-acm-flow.yaml'
-#    - '.github/workflows/merge-acm-prometheus-operator.yaml'
+  schedule:
+    - cron: '0 0 * * *' #@daily
+  pull_request:
+    paths:
+    - '.github/workflows/merge-acm-flow.yaml'
+    - '.github/workflows/merge-acm-prometheus-operator.yaml'
+  push:
+    paths:
+    - '.github/workflows/merge-acm-flow.yaml'
+    - '.github/workflows/merge-acm-prometheus-operator.yaml'
 jobs:
   acm-prometheus-operator-merge:
     uses: ./.github/workflows/merge-acm-flow.yaml

--- a/.github/workflows/merge-acm-prometheus.yaml
+++ b/.github/workflows/merge-acm-prometheus.yaml
@@ -2,16 +2,16 @@ name: ACM Prometheus merger
 
 on:
   workflow_dispatch:
-#  schedule:
-#    - cron: '0 0 * * *' #@daily
-#  pull_request:
-#    paths:
-#    - '.github/workflows/merge-acm-flow.yaml'
-#    - '.github/workflows/merge-acm-prometheus.yaml'
-#  push:
-#    paths:
-#    - '.github/workflows/merge-acm-flow.yaml'
-#    - '.github/workflows/merge-acm-prometheus.yaml'
+  schedule:
+    - cron: '0 0 * * *' #@daily
+  pull_request:
+    paths:
+    - '.github/workflows/merge-acm-flow.yaml'
+    - '.github/workflows/merge-acm-prometheus.yaml'
+  push:
+    paths:
+    - '.github/workflows/merge-acm-flow.yaml'
+    - '.github/workflows/merge-acm-prometheus.yaml'
 jobs:
   acm-prometheus-merge:
     uses: ./.github/workflows/merge-acm-flow.yaml

--- a/.github/workflows/merge-acm-thanos.yaml
+++ b/.github/workflows/merge-acm-thanos.yaml
@@ -1,4 +1,4 @@
-name: Thanos merger
+name: ACM Thanos merger
 
 on:
   workflow_dispatch:
@@ -17,8 +17,8 @@ jobs:
     uses: ./.github/workflows/merge-acm-flow.yaml
     with:
       upstream: thanos-io/thanos
-      downstream: openshift/thanos
-      sandbox: rhobs/thanos
+      downstream: stolostron/thanos
+      sandbox: rhobs/acm-thanos
       go-version: "1.22"
       restore-downstream: >-
         OWNERS

--- a/.github/workflows/merge-acm-thanos.yaml
+++ b/.github/workflows/merge-acm-thanos.yaml
@@ -3,7 +3,7 @@ name: ACM Thanos merger
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *' #@daily
+    - cron: '0 0 * * 1' #@weekly
   pull_request:
     paths:
     - '.github/workflows/merge-acm-flow.yaml'

--- a/.github/workflows/merge-acm-thanos.yaml
+++ b/.github/workflows/merge-acm-thanos.yaml
@@ -1,0 +1,40 @@
+name: Thanos merger
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' #@daily
+  pull_request:
+    paths:
+    - '.github/workflows/merge-acm-flow.yaml'
+    - '.github/workflows/merge-acm-thanos.yaml'
+  push:
+    paths:
+    - '.github/workflows/merge-acm-flow.yaml'
+    - '.github/workflows/merge-acm-thanos.yaml'
+jobs:
+  thanos-merge:
+    uses: ./.github/workflows/merge-acm-flow.yaml
+    with:
+      upstream: thanos-io/thanos
+      downstream: openshift/thanos
+      sandbox: rhobs/thanos
+      go-version: "1.22"
+      restore-downstream: >-
+        OWNERS
+      restore-upstream: >-
+        CHANGELOG.md
+        VERSION
+        docs
+        go.mod
+        go.sum
+        pkg
+        tutorials
+        .busybox-versions
+        .devcontainer
+    secrets:
+      pr-app-id: ${{ secrets.APP_ID }}
+      pr-app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      cloner-app-id: ${{ secrets.CLONER_APP_ID }}
+      cloner-app-private-key: ${{ secrets.CLONER_APP_PRIVATE_KEY }}
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/merge-alertmanager.yaml
+++ b/.github/workflows/merge-alertmanager.yaml
@@ -20,7 +20,7 @@ jobs:
       upstream: prometheus/alertmanager
       downstream: openshift/prometheus-alertmanager
       sandbox: rhobs/prometheus-alertmanager
-      go-version: "1.21"
+      go-version: "1.22"
       restore-upstream: >-
          CHANGELOG.md
          VERSION


### PR DESCRIPTION
Ticket - https://issues.redhat.com/browse/ACM-12368

There is an issue with listing and updating a PR from differently names forks with the actions `create-pull-request`. For now I have added an extra step using gh cli to get the PR URL and continue from there. 

Created an issue that is not allowing to update PR due to differently named Forks -> https://github.com/peter-evans/create-pull-request/issues/3030
