### PR TITLE
bugfix: support non-VERSION approach for KSM

### DIFF
--- a/.github/workflows/actions-ci-check.yaml
+++ b/.github/workflows/actions-ci-check.yaml
@@ -4,5 +4,5 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: reviewdog/action-actionlint@v1

--- a/.github/workflows/merge-flow.yaml
+++ b/.github/workflows/merge-flow.yaml
@@ -44,7 +44,7 @@ on:
         default: ''
         type: string
       downstream-version-expression:
-        description: Expression to extract downstream version from downstream repo.
+        description: Expression to extract downstream version from downstream repo. Follows the https://www.npmjs.com/package/semver spec.
         required: false
         default: ''
         type: string
@@ -88,14 +88,14 @@ jobs:
           DOWNSTREAM_VERSION=$(curl -sL "https://raw.githubusercontent.com/${{ inputs.downstream }}/${{ inputs.downstream-branch }}/VERSION")
           if [[ "${DOWNSTREAM_VERSION}" =~ ^$|"404: Not Found" ]]; then
             # Strip the trailing URL from the expression.
-            DOWNSTREAM_VERSION_SED=$(echo "${{ inputs.downstream-version-expression }}" | sed -e 's/\(http[^ ]*\).*$/\1/' -e 's/http[^ ]*$//')
+            DOWNSTREAM_VERSION_EXPRESSION=$(echo "${{ inputs.downstream-version-expression }}" | sed -e 's/\(http[^ ]*\).*$/\1/' -e 's/http[^ ]*$//')
             # Strip the leading sed command from the expression.
             DOWNSTREAM_VERSION_URL=$(echo "${{ inputs.downstream-version-expression }}" | sed -n 's/^.*\(http[^ ]*\).*$/\1/p')
-            if [ "${DOWNSTREAM_VERSION_SED}" == "" ] || [ "${DOWNSTREAM_VERSION_URL}" == "" ]; then
+            if [ "${DOWNSTREAM_VERSION_EXPRESSION}" == "" ] || [ "${DOWNSTREAM_VERSION_URL}" == "" ]; then
               echo "::error::downstream-version-expression is invalid"
               exit 1
             fi
-            DOWNSTREAM_VERSION=$(curl --silent "${DOWNSTREAM_VERSION_URL}" | eval "${DOWNSTREAM_VERSION_SED}")
+            DOWNSTREAM_VERSION=$(curl --silent "${DOWNSTREAM_VERSION_URL}" | eval "${DOWNSTREAM_VERSION_EXPRESSION}")
             if ! [[ "${DOWNSTREAM_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo "::error::downstream-version-expression is invalid"
               exit 1

--- a/.github/workflows/merge-kube-state-metrics.yaml
+++ b/.github/workflows/merge-kube-state-metrics.yaml
@@ -20,9 +20,12 @@ jobs:
       upstream: kubernetes/kube-state-metrics
       downstream: openshift/kube-state-metrics
       sandbox: rhobs/kube-state-metrics
-      go-version: "1.20"
-      restore-upstream: CHANGELOG.md VERSION
+      go-version: "1.22"
+      restore-upstream: |
+        CHANGELOG.md .github/ Dockerfile docs/ go.mod
       restore-downstream: OWNERS
+      downstream-version-expression: |
+        sed -n -E 's/^version: "*([0-9]+\.[0-9]+\.[0-9]+)"$/v\1/p' https://raw.githubusercontent.com/openshift/kube-state-metrics/main/data.yaml
     secrets:
       pr-app-id: ${{ secrets.APP_ID }}
       pr-app-private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
KSM dropped the `VERSION` file to reconcile with the structure in other sub-projects (such as the metrics-server) in the latest release. This patch addresses syncbot failing due to its absence.

***

Blocked-by: https://github.com/rhobs/syncbot/pull/92