### PR TITLE
chore: update prometheus-adapter version to 1.22

### DIFF
--- a/.github/workflows/merge-prometheus-adapter.yaml
+++ b/.github/workflows/merge-prometheus-adapter.yaml
@@ -19,7 +19,7 @@ jobs:
       upstream: kubernetes-sigs/prometheus-adapter
       downstream: openshift/k8s-prometheus-adapter
       sandbox: rhobs/k8s-prometheus-adapter
-      go-version: "1.20"
+      go-version: "1.22"
       restore-downstream: >-
          OWNERS
       restore-upstream: >-


### PR DESCRIPTION
Bump `prometheus-adapter` version to 1.22 so the bot recognizes the `toolchain` directive.