### PR TITLE
chore: bump checkout action for linter

### DIFF
--- a/.github/workflows/actions-ci-check.yaml
+++ b/.github/workflows/actions-ci-check.yaml
@@ -4,5 +4,5 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: reviewdog/action-actionlint@v1


### PR DESCRIPTION
Fixes false-positives such as https://github.com/rhobs/syncbot/pull/85/files.