### PR TITLE
chore: update metrics-server workflow

### DIFF
--- a/.github/workflows/merge-metrics-server.yaml
+++ b/.github/workflows/merge-metrics-server.yaml
@@ -20,8 +20,13 @@ jobs:
       upstream: kubernetes-sigs/metrics-server
       downstream: openshift/kubernetes-metrics-server
       sandbox: rhobs/kubernetes-metrics-server
-      go-version: "1.21"
-      restore-downstream: OWNERS charts/OWNERS
+      go-version: "1.22"
+      restore-downstream: >-
+         OWNERS
+         charts/OWNERS
+      restore-upstream: >-
+         go.mod
+         go.sum
       downstream-version-expression: |
         sed -n -E 's/^.*newTag: *(v[0-9]+\.[0-9]+\.[0-9]+).*$/\1/p' https://raw.githubusercontent.com/openshift/kubernetes-metrics-server/master/manifests/components/release/kustomization.yaml
     secrets:


### PR DESCRIPTION
update go version to 1.22 and
upstream and downstream restore files