### PR TITLE
Add "NO-JIRA:" prefix when bumping versions in CMO

### DIFF
--- a/.github/workflows/update-cmo-deps-versions.yaml
+++ b/.github/workflows/update-cmo-deps-versions.yaml
@@ -11,7 +11,7 @@ jobs:
     uses: ./.github/workflows/cmo-make-targets.yaml
     with:
       make-targets: versions generate
-      pr-title: "[bot] Synchronize versions of the downstream components"
+      pr-title: "NO-JIRA: [bot] Synchronize versions of the downstream components"
       pr-body: |
         ## Description
         This pull request updates `jsonnet/versions.yaml` to match with the **already in use** downstream versions of the monitoring components.


### PR DESCRIPTION
The PRs created by `update-cmo-deps-versions.yaml` don't require a JIRA ticket because they only update the version labels on the resources managed by CMO.