### PR TITLE
fix: support go.work in vendor step

### DIFF
--- a/.github/workflows/merge-flow.yaml
+++ b/.github/workflows/merge-flow.yaml
@@ -190,8 +190,14 @@ jobs:
       - name: go mod tidy + vendor
         run: |
           go mod tidy
-          go mod vendor
-          git add go.mod go.sum vendor
+          if [ -f go.work ]; then
+            echo "Detected go workspace"
+            go work vendor
+            git add go.mod go.sum go.work.sum vendor
+          else
+            go mod vendor
+            git add go.mod go.sum vendor
+          fi
           git diff --cached --exit-code || git commit -s -m "[bot] vendor: revendor"
       - name: Generate assets
         if: ${{ inputs.assets-cmd != '' }}


### PR DESCRIPTION
mainly for prometheus
see https://github.com/openshift/release/pull/78351/changes

---

Prometheus merger is working now, but I'll block it as it may break https://github.com/openshift/prometheus/pull/312
will re-enable it later