### PR TITLE
Use peter-evans/create-pull-request@v8 action

### DIFF
--- a/.github/workflows/merge-flow.yaml
+++ b/.github/workflows/merge-flow.yaml
@@ -227,7 +227,7 @@ jobs:
           scope: ${{ steps.org.outputs.sandbox }}
       - name: Create Pull Request
         if: github.event_name != 'pull_request'
-        uses: rhobs/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v8
         id: create-pr
         with:
           title: "[bot] Bump ${{ inputs.downstream }} to ${{ steps.upstream.outputs.release }}"
@@ -242,7 +242,8 @@ jobs:
           delete-branch: true
           token: ${{ steps.pr.outputs.token }}
           push-to-fork: ${{ inputs.sandbox }}
-          push-to-fork-token: ${{ steps.cloner.outputs.token }}
+          branch-token: ${{ steps.cloner.outputs.token }}
+          maintainer-can-modify: false
       - name: Compose slack message body
         if: github.event_name != 'pull_request' && (success() || steps.fork-sync.outputs.status == 'uptodate' || steps.fork-sync.outputs.status == 'ahead')
         continue-on-error: true


### PR DESCRIPTION
This commit replaces the `rhobs/create-pull-request@v3` action by `peter-evans/create-pull-request@v8`. We had to maintain a custom action in the past because the `peter-evans/create-pull-request@v8` action didn't offer the capabilities that we needed but it shouldn't be the case anymore.