### PR TITLE
Bump prometheus-operator jsonnet pin in CMO alongside merge

### DIFF
--- a/.github/workflows/cmo-make-targets.yaml
+++ b/.github/workflows/cmo-make-targets.yaml
@@ -62,6 +62,7 @@ jobs:
           git checkout -- jsonnet/jsonnetfile.lock.json;
         fi
     - name: Get app token for pull request creation
+      if: github.event_name != 'pull_request'
       id: pr
       uses: actions/create-github-app-token@v3
       with:
@@ -69,6 +70,7 @@ jobs:
         private-key: ${{ secrets.pr-app-private-key }}
         owner: openshift
     - name: Get app token for repository cloning
+      if: github.event_name != 'pull_request'
       id: cloner
       uses: actions/create-github-app-token@v3
       with:
@@ -80,6 +82,7 @@ jobs:
       run: |
         echo sandbox="$(echo ${{ inputs.make-targets }} | sed 's/ /-/g')" >> "$GITHUB_OUTPUT"
     - name: Create Pull Request
+      if: github.event_name != 'pull_request'
       id: create-pr
       uses: peter-evans/create-pull-request@v8
       with:
@@ -96,6 +99,7 @@ jobs:
         branch-token: ${{ steps.cloner.outputs.token }}
         maintainer-can-modify: false
     - name: Compose slack message body
+      if: github.event_name != 'pull_request' && success()
       id: slack-message
       run: |
         if [ "${{ steps.create-pr.outputs.pull-request-url }}" == "" ]; then
@@ -107,7 +111,7 @@ jobs:
         fi
     - uses: slackapi/slack-github-action@v3
       continue-on-error: true
-      if: success()
+      if: github.event_name != 'pull_request' && success()
       with:
         webhook: ${{ secrets.slack-webhook-url }}
         webhook-type: incoming-webhook
@@ -120,7 +124,7 @@ jobs:
           }
     - uses: slackapi/slack-github-action@v3
       continue-on-error: true
-      if: failure()
+      if: github.event_name != 'pull_request' && failure()
       with:
         webhook: ${{ secrets.slack-webhook-url }}
         webhook-type: incoming-webhook

--- a/.github/workflows/cmo-make-targets.yaml
+++ b/.github/workflows/cmo-make-targets.yaml
@@ -14,6 +14,11 @@ on:
         description: List of make targets to be executed sequentially.
         required: true
         type: string
+      pre-run:
+        description: Optional shell commands to run before make targets.
+        required: false
+        default: ''
+        type: string
     secrets:
       cloner-app-id:
         description: Github ID of cloner app
@@ -44,6 +49,9 @@ jobs:
     - uses: actions/setup-go@v6
       with:
         go-version-file: go.mod
+    - name: Pre-run commands
+      if: ${{ inputs.pre-run != '' }}
+      run: ${{ inputs.pre-run }}
     - name: Execute make targets - ${{ inputs.make-targets }}
       run: make ${{ inputs.make-targets }}
     - name: Ignore if change is only in jsonnetfile.lock.json

--- a/.github/workflows/merge-flow.yaml
+++ b/.github/workflows/merge-flow.yaml
@@ -60,11 +60,17 @@ on:
       slack-webhook-url:
         description: Slack webhook URL to send notification
         required: true
+    outputs:
+      upstream-release:
+        description: The latest upstream release tag (e.g. "v0.92.0")
+        value: ${{ jobs.merge.outputs.upstream-release }}
 
 jobs:
   merge:
     runs-on: ubuntu-latest
     name: Perform merge operation
+    outputs:
+      upstream-release: ${{ steps.upstream.outputs.release }}
     steps:
       - name: Get latest upstream tag
         id: upstream

--- a/.github/workflows/merge-prometheus-operator.yaml
+++ b/.github/workflows/merge-prometheus-operator.yaml
@@ -36,3 +36,74 @@ jobs:
       cloner-app-id: ${{ secrets.CLONER_APP_ID }}
       cloner-app-private-key: ${{ secrets.CLONER_APP_PRIVATE_KEY }}
       slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  # Bump the prometheus-operator jsonnet branch pin in CMO so that CRD schemas
+  # and other generated assets stay in sync with the upstream release.
+  check-prometheus-operator-jsonnet-pin:
+    needs: prometheus-operator-merge
+    # Run even if the merge job fails (e.g. due to conflicts).
+    if: always() && needs.prometheus-operator-merge.outputs.upstream-release != ''
+    runs-on: ubuntu-latest
+    outputs:
+      release-branch: ${{ steps.resolve.outputs.release-branch }}
+      should-update: ${{ steps.resolve.outputs.should-update }}
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        repository: openshift/cluster-monitoring-operator
+        ref: main
+        sparse-checkout: jsonnet/jsonnetfile.json
+    - name: Resolve release branch from upstream tag
+      id: resolve
+      env:
+        UPSTREAM_TAG: ${{ needs.prometheus-operator-merge.outputs.upstream-release }}
+      run: |
+        # v0.92.0 -> release-0.92
+        RELEASE_BRANCH="release-${UPSTREAM_TAG#v}" && RELEASE_BRANCH="${RELEASE_BRANCH%.*}"
+
+        CURRENT=$(jq -r --arg remote "https://github.com/prometheus-operator/prometheus-operator" \
+          '(.dependencies[] | select(.source.git.remote == $remote)).version' \
+          jsonnet/jsonnetfile.json)
+
+        echo "latest: $RELEASE_BRANCH, current: $CURRENT"
+        echo "release-branch=$RELEASE_BRANCH" >> "$GITHUB_OUTPUT"
+
+        if [ "$CURRENT" = "$RELEASE_BRANCH" ]; then
+          echo "should-update=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "should-update=true" >> "$GITHUB_OUTPUT"
+        fi
+
+  bump-prometheus-operator-jsonnet:
+    needs: check-prometheus-operator-jsonnet-pin
+    # Skip if already pinned to the same release branch; another workflow handles updates within the same pin.
+    if: needs.check-prometheus-operator-jsonnet-pin.outputs.should-update == 'true'
+    uses: ./.github/workflows/cmo-make-targets.yaml
+    with:
+      pre-run: |
+        REMOTE="https://github.com/prometheus-operator/prometheus-operator"
+        BRANCH="${{ needs.check-prometheus-operator-jsonnet-pin.outputs.release-branch }}"
+
+        jq --arg remote "$REMOTE" --arg branch "$BRANCH" \
+          '(.dependencies[] | select(.source.git.remote == $remote)).version = $branch' \
+          jsonnet/jsonnetfile.json > jsonnet/jsonnetfile.json.tmp
+
+        mv jsonnet/jsonnetfile.json.tmp jsonnet/jsonnetfile.json
+      make-targets: update COMPONENTS=https://github.com/prometheus-operator/prometheus-operator/jsonnet/prometheus-operator generate
+      pr-title: "[bot] Bump prometheus-operator jsonnet release branch to ${{ needs.check-prometheus-operator-jsonnet-pin.outputs.release-branch }}"
+      pr-body: |
+        ## Description
+        Updates the prometheus-operator jsonnet branch pin in
+        [`jsonnet/jsonnetfile.json`](https://github.com/openshift/cluster-monitoring-operator/blob/main/jsonnet/jsonnetfile.json)
+        to match the latest upstream release, and regenerates all
+        assets including prometheus-operator CRDs YAMLs.
+
+        Note: the [downstream openshift/prometheus-operator](https://github.com/openshift/prometheus-operator/blob/main/VERSION)
+        may still be on an older version.
+        That is not necessarily a blocker for this PR.
+    secrets:
+      pr-app-id: ${{ secrets.APP_ID }}
+      pr-app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      cloner-app-id: ${{ secrets.CLONER_APP_ID }}
+      cloner-app-private-key: ${{ secrets.CLONER_APP_PRIVATE_KEY }}
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/merge-prometheus-operator.yaml
+++ b/.github/workflows/merge-prometheus-operator.yaml
@@ -41,7 +41,7 @@ jobs:
   # and other generated assets stay in sync with the upstream release.
   check-prometheus-operator-jsonnet-pin:
     needs: prometheus-operator-merge
-    # Run even if the merge job fails (e.g. due to conflicts).
+    # Run even if the merge job fails (e.g. due to conflicts). We still need a PR anyway.
     if: always() && needs.prometheus-operator-merge.outputs.upstream-release != ''
     runs-on: ubuntu-latest
     outputs:
@@ -96,11 +96,12 @@ jobs:
         Updates the prometheus-operator jsonnet branch pin in
         [`jsonnet/jsonnetfile.json`](https://github.com/openshift/cluster-monitoring-operator/blob/main/jsonnet/jsonnetfile.json)
         to match the latest upstream release, and regenerates all
-        assets including prometheus-operator CRDs YAMLs.
+        assets (CRDs YAMLs, etc.).
 
         Note: the [downstream openshift/prometheus-operator](https://github.com/openshift/prometheus-operator/blob/main/VERSION)
         may still be on an older version.
-        That is not necessarily a blocker for this PR.
+        That is not necessarily a blocker; in fact, landing this PR
+        first may unblock the downstream fork bump.
     secrets:
       pr-app-id: ${{ secrets.APP_ID }}
       pr-app-private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
Alongside the prometheus-operator merge job, derive the release
branch from the upstream tag and update the jsonnet pin in CMO's
jsonnetfile.json (scoped to only the prometheus-operator dependency).
Skips if already on the latest release branch to avoid overlapping
with the general jsonnet deps update workflow.

Also exposes upstream-release as an output of merge-flow.yaml.