### PR TITLE
ACM-37051: fix: prevent duplicate Authorization header in merge workflow

### DIFF
--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -133,6 +133,7 @@ jobs:
           repository: ${{ inputs.downstream }}
           fetch-depth: 0
           ref: ${{ inputs.downstream-branch }}
+          persist-credentials: false
       - name: Fetch upstream tag
         run: |
           git config user.name 'github-actions[bot]'


### PR DESCRIPTION
## Summary
- Add `persist-credentials: false` to `actions/checkout@v7` in the merge workflow
- Fixes `Duplicate header: "Authorization"` HTTP 400 error when the create-pull-request action pushes to the sandbox fork

## Root cause
`actions/checkout@v7` persists its GITHUB_TOKEN credential via `includeIf.gitdir` in the git config. When `rhobs/acm-create-pull-request@push-to-fork-token` later sets its own GitHub App token credential, both resolve for `github.com`, causing git to send two `Authorization` headers. GitHub rejects this with HTTP 400.

## Why now
This started after `actions/checkout` was bumped from v6 to v7 in #146. Checkout v7 changed how credentials are persisted — it now uses a separate credentials file included via `includeIf.gitdir`, which stacks with (rather than being overwritten by) the create-pull-request action's local config credential.

## Test plan
- [ ] Re-run the [failing thanos-merge workflow](https://github.com/rhobs/syncbot/actions/runs/28590152527) after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)