### PR TITLE
MON-4603:  Fixes the metrics-server merger workflow 

### DIFF
--- a/.github/workflows/merge-flow.yaml
+++ b/.github/workflows/merge-flow.yaml
@@ -39,6 +39,11 @@ on:
         required: false
         default: ''
         type: string
+      remove-paths:
+        description: List of paths to remove from the downstream fork after merge.
+        required: false
+        default: ''
+        type: string
       downstream-version-expression:
         description: Expression to extract downstream version from downstream repo. Follows the https://www.npmjs.com/package/semver spec.
         required: false
@@ -159,6 +164,13 @@ jobs:
         if: ${{ steps.merge.outputs.MERGE_CONFLICT == 'true' }}
         run: |
             git status --porcelain | awk '{ if ($1=="DU") print $2 }' | xargs -I {} git rm {}
+      - name: Remove unwanted paths
+        if: inputs.remove-paths != ''
+        run: |
+            git rm -rf --ignore-unmatch ${{ inputs.remove-paths }}
+            if [ "${{ steps.merge.outputs.MERGE_CONFLICT }}" != "true" ]; then
+              git diff --cached --exit-code || git commit -s -m "[bot] remove unwanted paths"
+            fi
       - name: Continue after merge conflict
         if: ${{ steps.merge.outputs.MERGE_CONFLICT == 'true' }}
         run: |

--- a/.github/workflows/merge-flow.yaml
+++ b/.github/workflows/merge-flow.yaml
@@ -150,6 +150,11 @@ jobs:
             echo "reset ${{ inputs.restore-downstream }}"
             git checkout --ours ${{ inputs.restore-downstream }}
             git add ${{ inputs.restore-downstream }}
+      - name: Resolve conflict due to deleted upstream files
+        if: ${{ steps.merge.outputs.MERGE_CONFLICT == 'true' }}
+        run: |
+            # Accept upstream deletions after restore-downstream has preserved downstream-only files.
+            git status --porcelain | awk '{ if ($1=="UD") print $2 }' | xargs -r git rm
       - name: Resolve conflict due to deleted downstream files
         if: ${{ steps.merge.outputs.MERGE_CONFLICT == 'true' }}
         run: |

--- a/.github/workflows/merge-metrics-server.yaml
+++ b/.github/workflows/merge-metrics-server.yaml
@@ -20,18 +20,18 @@ jobs:
       upstream: kubernetes-sigs/metrics-server
       downstream: openshift/kubernetes-metrics-server
       sandbox: rhobs/kubernetes-metrics-server
-      restore-downstream: >-
-        OWNERS
-        charts/OWNERS
+      restore-downstream: OWNERS
       restore-upstream: >-
         go.mod
         go.sum
         Dockerfile
         Makefile
-        scripts/go.mod
-        scripts/go.sum
         README.md
         manifests/components/release/kustomization.yaml
+      remove-paths: >-
+        charts
+        .github/workflows/lint-test-chart.yaml
+        .github/workflows/release-chart.yaml
       downstream-version-expression: |
         sed -n -E 's/^.*newTag: *(v[0-9]+\.[0-9]+\.[0-9]+).*$/\1/p' https://raw.githubusercontent.com/openshift/kubernetes-metrics-server/main/manifests/components/release/kustomization.yaml
     secrets:


### PR DESCRIPTION
The [failed run #1172](https://github.com/rhobs/syncbot/actions/runs/29295898742/job/86969209666) hit a merge conflict when git checkout --theirs was run on scripts/go.mod and scripts/go.sum — files upstream deleted in v0.9.0 but still present in the OpenShift fork.

Also Adds an opt-in remove-paths input so individual merger workflows can drop paths not needed in OpenShift downstream forks, incase of metrics-server remove the helm charts which are not needed downstream