### PR TITLE
Remove restore-downstream from merge workflow

### DIFF
--- a/.github/workflows/merge-acm-prometheus.yaml
+++ b/.github/workflows/merge-acm-prometheus.yaml
@@ -20,9 +20,6 @@ jobs:
       downstream: stolostron/prometheus
       sandbox: rhobs/acm-prometheus
       go-mod-tidy: false
-      restore-downstream: >-
-        plugins.yml
-        plugins
       restore-upstream: >-
         CHANGELOG.md
         Makefile


### PR DESCRIPTION
Removed restore-downstream configuration from the workflow. since .plugins.yml doesnt exist

https://github.com/rhobs/syncbot/actions/runs/29842258324/job/88673824353