### PR TITLE
workflows: add pnpm setup and improve Prometheus asset compression

### DIFF
--- a/.github/workflows/merge-acm-flow.yaml
+++ b/.github/workflows/merge-acm-flow.yaml
@@ -194,6 +194,9 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node-version }}
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: "> 11.12.0"
       - name: go mod tidy + vendor
         if: ${{ inputs.go-mod-tidy }}
         run: |

--- a/.github/workflows/merge-acm-prometheus.yaml
+++ b/.github/workflows/merge-acm-prometheus.yaml
@@ -20,9 +20,6 @@ jobs:
       downstream: stolostron/prometheus
       sandbox: rhobs/acm-prometheus
       go-mod-tidy: false
-      restore-downstream: >-
-        plugins.yml
-        plugins
       restore-upstream: >-
         CHANGELOG.md
         Makefile

--- a/.github/workflows/merge-acm-prometheus.yaml
+++ b/.github/workflows/merge-acm-prometheus.yaml
@@ -34,10 +34,12 @@ jobs:
         # Only compress assets if assets actually changed
         # The git diff relies on gits remote naming. The merge-flow checks out
         # $downstream as origin at the time of writing this code.
-        if ! git diff --exit-code --name-only  origin/main web/ui; then
-          find web/ui/static -type f -name '*.gz' -exec git add {} \;
-          git add web/ui
-          git diff --cached --exit-code --name-only || git commit -s -m "[bot] assets: generate"
+        if ! git diff --exit-code origin/main web/ui; then
+          # Only build the Mantine UI.
+          BUILD_UI=mantine make assets-compress
+          find web/ui/static/mantine-ui -type f -name '*.gz' -exec git add {} \;
+          git add web/ui/embed.go
+          git diff --cached --exit-code || git commit -s -m "[bot] assets: generate"
         fi
 
     secrets:


### PR DESCRIPTION
Add pnpm/action-setup to merge-acm-flow and update Prometheus workflow to only build Mantine UI assets.