### PR TITLE
Add -f flag for web/ui/static/mantine UI 

### DIFF
--- a/.github/workflows/merge-acm-prometheus.yaml
+++ b/.github/workflows/merge-acm-prometheus.yaml
@@ -34,7 +34,7 @@ jobs:
         if ! git diff --exit-code origin/main web/ui; then
           # Only build the Mantine UI.
           BUILD_UI=mantine make assets-compress
-          find web/ui/static/mantine-ui -type f -name '*.gz' -exec git add {} \;
+          find web/ui/static/mantine-ui -type f -name '*.gz' -exec git add -f {} \;
           git add web/ui/embed.go
           git diff --cached --exit-code || git commit -s -m "[bot] assets: generate"
         fi


### PR DESCRIPTION
Without the -f flag, git add silently skips gitignored files, so the compressed Mantine UI assets were never actually staged or committed. This meant the embed.go file referenced assets that didn't exist in the repo. This change forces Git to stage the .gz files despite the .gitignore rule.